### PR TITLE
Fix: GitHub Actions语法错误。其他分支早已同步修改，但忘记dev分支了

### DIFF
--- a/.github/workflows/apply-branch-protection.yml
+++ b/.github/workflows/apply-branch-protection.yml
@@ -9,8 +9,7 @@ on:
         default: 'no'
 
 permissions:
-  contents: read
-  administration: write
+  contents: write
 
 jobs:
   apply-protection:


### PR DESCRIPTION
- 将无效的administration权限改为contents:write
- 解决工作流文件解析错误

## 变更描述 / Description

修复 GitHub Actions 工作流文件中的权限配置语法错误。原配置文件使用了无效的权限作用域 administration: write，导致每次 PR 时工作流都无法加载并报错。

## 变更类型 / Type of Change

- [X] 🐛 Bug 修复 (Bug fix)
- [ ] ✨ 新功能 (New feature)
- [ ] 🔧 重构 (Refactor)
- [ ] 📝 文档更新 (Documentation update)
- [ ] 🔒 安全修复 (Security fix)
- [ ] 其他 (Other): ___

## 测试说明 / Testing

测试步骤：

- 验证语法：已通过 GitHub Actions 编辑器验证文件语法正确
- 权限验证：contents: write权限足以执行分支保护操作
- 功能验证：修复后，工作流应能正常执行，不再报 Invalid workflow file错误

- [X] 已在本地通过测试 / Tests pass locally

## 检查清单 / Checklist

- [X] 代码符合项目风格规范 / Code follows project style guidelines
- [X] 已完成自我审查 / Self-review completed
- [X] 相关文档已更新（如有需要）/ Documentation updated (if needed)
- [X] 无新增安全漏洞 / No new security vulnerabilities introduced

## 关联 Issue / Related Issue

无
