### PR TITLE
Frontend: mobile upload real-chain flow + schema fallback rendering

### DIFF
--- a/frontend_v2_premium/api.js
+++ b/frontend_v2_premium/api.js
@@ -5,8 +5,34 @@
 window.API = (() => {
     const GATEWAY_STALE_MS = 5 * 60 * 1000;
     const DEFAULT_LIMIT = 300;
+    const DEFAULT_UPLOAD_RETRIES = 2;
+    const DEFAULT_UPLOAD_TIMEOUT_MS = 45000;
     const schemaBySensor = new Map();
+    let schemaSource = 'remote';
     let telemetryRecords = [];
+    const FALLBACK_SCHEMA = {
+        sensors: [
+            {
+                sensor_id: 'soil_modbus_02',
+                trend_metric: 'ec',
+                category_metric: 'slave_id',
+                fields: [
+                    { field: 'vwc', label: 'Soil Moisture', unit: '%', data_type: 'f32', required: true, threshold_low: 20, threshold_high: 70 },
+                    { field: 'temp_c', label: 'Temperature', unit: 'C', data_type: 'f32', required: true, threshold_low: 0, threshold_high: 45 },
+                    { field: 'ec', label: 'Soil Fertility', unit: 'uS/cm', data_type: 'f32', required: true, threshold_low: 0, threshold_high: 5000 },
+                ],
+            },
+            {
+                sensor_id: 'dht22',
+                trend_metric: 'temp_c',
+                category_metric: null,
+                fields: [
+                    { field: 'temp_c', label: 'Temperature', unit: 'C', data_type: 'f32', required: true, threshold_low: 0, threshold_high: 50 },
+                    { field: 'hum', label: 'Humidity', unit: '%', data_type: 'f32', required: true, threshold_low: 20, threshold_high: 95 },
+                ],
+            },
+        ],
+    };
 
     const fetchJson = async (url) => {
         const res = await fetch(url, { cache: 'no-store' });
@@ -52,34 +78,46 @@ window.API = (() => {
 
     const getLatestBySensor = (sensorId) => telemetryRecords.find((row) => row.sensor_id === sensorId) || null;
 
-    const loadSchema = async () => {
+    const loadSchemaFromPayload = (payload) => {
         schemaBySensor.clear();
-        try {
-            const payload = await fetchJson('/api/v1/sensor/schema');
-            const sensors = Array.isArray(payload?.sensors) ? payload.sensors : [];
-            sensors.forEach((sensor) => {
-                if (!sensor?.sensor_id) return;
-                const fields = new Map();
-                (sensor.fields || []).forEach((field) => {
-                    if (!field?.field) return;
-                    fields.set(field.field, {
-                        field: field.field,
-                        label: field.label || field.field,
-                        unit: field.unit || '',
-                        data_type: field.data_type || 'string',
-                        required: !!field.required,
-                        threshold_low: typeof field.threshold_low === 'number' ? field.threshold_low : null,
-                        threshold_high: typeof field.threshold_high === 'number' ? field.threshold_high : null,
-                    });
-                });
-                schemaBySensor.set(sensor.sensor_id, {
-                    trendMetric: sensor.trend_metric || null,
-                    categoryMetric: sensor.category_metric || null,
-                    fields,
+        const sensors = Array.isArray(payload?.sensors) ? payload.sensors : [];
+        sensors.forEach((sensor) => {
+            if (!sensor?.sensor_id) return;
+            const fields = new Map();
+            (sensor.fields || []).forEach((field) => {
+                if (!field?.field) return;
+                fields.set(field.field, {
+                    field: field.field,
+                    label: field.label || field.field,
+                    unit: field.unit || '',
+                    data_type: field.data_type || 'string',
+                    required: !!field.required,
+                    threshold_low: typeof field.threshold_low === 'number' ? field.threshold_low : null,
+                    threshold_high: typeof field.threshold_high === 'number' ? field.threshold_high : null,
                 });
             });
+            schemaBySensor.set(sensor.sensor_id, {
+                trendMetric: sensor.trend_metric || null,
+                categoryMetric: sensor.category_metric || null,
+                fields,
+            });
+        });
+    };
+
+    const loadSchema = async () => {
+        schemaBySensor.clear();
+        schemaSource = 'remote';
+        try {
+            const payload = await fetchJson('/api/v1/sensor/schema');
+            loadSchemaFromPayload(payload);
+            if (!schemaBySensor.size) {
+                loadSchemaFromPayload(FALLBACK_SCHEMA);
+                schemaSource = 'fallback';
+            }
         } catch (err) {
             console.warn('Schema loading failed:', err);
+            loadSchemaFromPayload(FALLBACK_SCHEMA);
+            schemaSource = 'fallback';
         }
     };
 
@@ -108,7 +146,7 @@ window.API = (() => {
             const value = fields[field];
             if (value === undefined || value === null || value === '') return;
             const dataType = `${spec.data_type || ''}`.toLowerCase();
-            const numericTypes = ['number', 'float', 'f32', 'f64', 'u8', 'u16', 'u32', 'i32'];
+            const numericTypes = ['number', 'float', 'f32', 'f64', 'u8', 'u16', 'u32', 'u64', 'i32', 'i64'];
             if (!numericTypes.includes(dataType)) return;
             const num = Number(value);
             if (!Number.isFinite(num)) {
@@ -215,6 +253,106 @@ window.API = (() => {
         return { devices, cropTypes, locations };
     };
 
+    const maybeConvertForUpload = async (file) => {
+        if (!file) throw new Error('No image file selected');
+        const type = `${file.type || ''}`.toLowerCase();
+        const heicLike = type.includes('heic') || type.includes('heif') || /\.(heic|heif)$/i.test(file.name || '');
+        if (!heicLike) {
+            return file;
+        }
+        if (typeof createImageBitmap !== 'function') {
+            throw new Error('HEIC conversion is not supported on this browser. Please upload jpg/png.');
+        }
+        try {
+            const imageBitmap = await createImageBitmap(file);
+            const canvas = document.createElement('canvas');
+            canvas.width = imageBitmap.width;
+            canvas.height = imageBitmap.height;
+            const ctx = canvas.getContext('2d');
+            if (!ctx) throw new Error('Canvas context unavailable');
+            ctx.drawImage(imageBitmap, 0, 0);
+            imageBitmap.close();
+            const jpegBlob = await new Promise((resolve, reject) => {
+                canvas.toBlob(
+                    (blob) => (blob ? resolve(blob) : reject(new Error('HEIC to JPEG conversion failed'))),
+                    'image/jpeg',
+                    0.92,
+                );
+            });
+            const baseName = (file.name || 'upload').replace(/\.(heic|heif)$/i, '');
+            return new File([jpegBlob], `${baseName}.jpg`, { type: 'image/jpeg' });
+        } catch (err) {
+            throw new Error(`HEIC conversion failed: ${err.message || err}`);
+        }
+    };
+
+    const buildUploadQuery = (tag) =>
+        apiUrl('/api/v1/image/upload', {
+            device_id: tag?.device_id || '',
+            ts: tag?.ts || new Date().toISOString(),
+            location: tag?.location || '',
+            crop_type: tag?.crop_type || '',
+            farm_note: tag?.farm_note || '',
+        });
+
+    const uploadImageOnce = ({ file, tag, timeoutMs, onProgress }) =>
+        new Promise((resolve, reject) => {
+            const xhr = new XMLHttpRequest();
+            xhr.open('POST', buildUploadQuery(tag), true);
+            xhr.timeout = timeoutMs;
+            xhr.onload = () => {
+                const payloadText = xhr.responseText || '{}';
+                let payload = {};
+                try {
+                    payload = JSON.parse(payloadText);
+                } catch (err) {
+                    reject(new Error(`Upload response is not JSON: ${payloadText.slice(0, 120)}`));
+                    return;
+                }
+                if (xhr.status >= 200 && xhr.status < 300 && payload?.status === 'success') {
+                    resolve(payload);
+                    return;
+                }
+                const message = payload?.message || `HTTP ${xhr.status}`;
+                reject(new Error(message));
+            };
+            xhr.onerror = () => reject(new Error('Network error while uploading image'));
+            xhr.ontimeout = () => reject(new Error(`Upload timeout (${timeoutMs} ms)`));
+            xhr.upload.onprogress = (evt) => {
+                if (!evt.lengthComputable || typeof onProgress !== 'function') return;
+                onProgress(Math.round((evt.loaded / evt.total) * 100));
+            };
+
+            const form = new FormData();
+            form.append('file', file, file.name || 'upload.jpg');
+            xhr.send(form);
+        });
+
+    const uploadImage = async ({ file, tag, retries = DEFAULT_UPLOAD_RETRIES, timeoutMs = DEFAULT_UPLOAD_TIMEOUT_MS, onProgress }) => {
+        const deviceId = `${tag?.device_id || ''}`.trim();
+        if (!deviceId) throw new Error('device_id is required for upload');
+        const preparedFile = await maybeConvertForUpload(file);
+        let lastErr = null;
+        for (let attempt = 0; attempt <= retries; attempt += 1) {
+            try {
+                if (typeof onProgress === 'function') onProgress(0);
+                const result = await uploadImageOnce({
+                    file: preparedFile,
+                    tag: { ...tag, device_id: deviceId, ts: tag?.ts || new Date().toISOString() },
+                    timeoutMs,
+                    onProgress,
+                });
+                if (typeof onProgress === 'function') onProgress(100);
+                return result;
+            } catch (err) {
+                lastErr = err;
+                if (attempt >= retries) break;
+                await new Promise((resolve) => setTimeout(resolve, 800 * (attempt + 1)));
+            }
+        }
+        throw lastErr || new Error('Image upload failed');
+    };
+
 
 
     return {
@@ -231,5 +369,8 @@ window.API = (() => {
         formatNumeric,
         fetchHistory,
         fetchDevices,
+        uploadImage,
+        isSchemaFallback: () => schemaSource === 'fallback',
+        getSchemaSource: () => schemaSource,
     };
 })();

--- a/frontend_v2_premium/app.js
+++ b/frontend_v2_premium/app.js
@@ -5,11 +5,11 @@
 
 window.onload = async () => {
     const params = new URLSearchParams(window.location.search);
-    const deviceId = (params.get('device_id') || localStorage.getItem('device_id') || '').trim();
-    if (deviceId) localStorage.setItem('device_id', deviceId);
+    let activeDeviceId = (params.get('device_id') || localStorage.getItem('device_id') || '').trim();
+    if (activeDeviceId) localStorage.setItem('device_id', activeDeviceId);
     
     const ctxTitle = document.getElementById('ctxDevice');
-    if (ctxTitle) ctxTitle.textContent = `Node: ${deviceId || 'GLOBAL'}`;
+    if (ctxTitle) ctxTitle.textContent = `Node: ${activeDeviceId || 'GLOBAL'}`;
 
     // 1. Initialize Global UI Components (Clock)
     setInterval(() => {
@@ -23,11 +23,22 @@ window.onload = async () => {
     // 3. Load Schema & Initial Data
     await window.API.loadSchema();
     window.UI.HomePositioning.init();
+    window.UI.Upload.init(activeDeviceId);
     window.UI.AI.init();
-    await updateAppLoop(deviceId);
+    await updateAppLoop(activeDeviceId);
+
+    window.APP = {
+        refreshNow: async () => {
+            activeDeviceId = (localStorage.getItem('device_id') || activeDeviceId || '').trim();
+            await updateAppLoop(activeDeviceId);
+        },
+    };
 
     // 4. Start Interval
-    setInterval(() => updateAppLoop(deviceId), 15000);
+    setInterval(() => {
+        activeDeviceId = (localStorage.getItem('device_id') || activeDeviceId || '').trim();
+        updateAppLoop(activeDeviceId);
+    }, 15000);
 
     // Initial Resize
     window.UI.switchView('view-home');

--- a/frontend_v2_premium/index.html
+++ b/frontend_v2_premium/index.html
@@ -252,15 +252,27 @@
                       <!-- Gateway Visuals -->
                       <div class="grid grid-cols-1 xl:grid-cols-2 gap-6">
                           <div class="glass-panel p-6">
-                              <h2 class="text-sm font-bold text-slate-100 mb-6 flex items-center gap-2 uppercase tracking-widest"><i class="fa fa-camera text-blue-400"></i><span data-i18n="gateway_vision">网关实时视觉</span></h2>
-                              <div class="aspect-video bg-black/40 rounded-xl overflow-hidden border border-white/5 relative group">
-                                  <div class="absolute inset-0 bg-gradient-to-t from-black/60 to-transparent"></div>
-                                  <div class="absolute bottom-4 left-4">
-                                      <p class="text-[10px] text-white/60 font-mono tracking-widest">GATEWAY_CAM_01</p>
-                                      <p class="text-xs text-white" data-i18n="live_streaming">实时推流中...</p>
-                                  </div>
-                                  <!-- Shimmer Overlay -->
-                                  <div class="absolute inset-0 bg-gradient-to-r from-transparent via-white/5 to-transparent -translate-x-full animate-[shimmer_2s_infinite]"></div>
+                              <h2 class="text-sm font-bold text-slate-100 mb-4 flex items-center gap-2 uppercase tracking-widest"><i class="fa fa-camera text-blue-400"></i><span>手机图传上传</span></h2>
+                              <p class="text-[11px] text-slate-400 mb-4">仅真实链路：图片将通过 <span class="font-mono text-emerald-300">/api/v1/image/upload</span> 上传并触发 AI 入库。</p>
+                              <input id="mobileUploadInput" type="file" accept="image/*,.jpg,.jpeg,.png,.heic,.heif" capture="environment" class="hidden" />
+                              <div class="grid grid-cols-1 md:grid-cols-[1fr_auto_auto] gap-2 mb-3">
+                                  <button id="mobileUploadPickBtn" class="px-3 py-2 rounded-lg bg-white/10 border border-white/15 text-xs text-slate-100 hover:bg-white/20 transition-all">
+                                      <i class="fa fa-camera mr-1"></i>拍照 / 选图
+                                  </button>
+                                  <button id="mobileUploadClearBtn" class="px-3 py-2 rounded-lg bg-black/30 border border-white/10 text-xs text-slate-300 hover:text-white transition-all">清空</button>
+                                  <button id="mobileUploadSubmitBtn" class="px-3 py-2 rounded-lg bg-emerald-600/80 border border-emerald-400/30 text-xs text-white hover:bg-emerald-500 disabled:opacity-50 disabled:cursor-not-allowed transition-all" disabled>上传</button>
+                              </div>
+                              <p id="mobileUploadFileName" class="text-[11px] text-slate-400 mb-3 font-mono truncate">No image selected</p>
+                              <div class="aspect-video bg-black/40 rounded-xl overflow-hidden border border-white/10 relative mb-3">
+                                  <img id="mobileUploadPreview" src="" alt="preview" class="hidden w-full h-full object-cover" />
+                                  <div id="mobileUploadPreviewEmpty" class="absolute inset-0 flex items-center justify-center text-slate-500 text-xs">等待图片...</div>
+                              </div>
+                              <div class="w-full bg-black/30 rounded-full h-1.5 overflow-hidden border border-white/10">
+                                  <div id="mobileUploadProgressBar" class="h-full bg-emerald-400 transition-all" style="width:0%"></div>
+                              </div>
+                              <div class="flex items-center justify-between mt-2">
+                                  <p id="mobileUploadStatus" class="text-[11px] text-slate-400">Ready for upload.</p>
+                                  <span id="mobileUploadProgressText" class="text-[10px] text-slate-500 font-mono">0%</span>
                               </div>
                           </div>
 
@@ -275,6 +287,7 @@
                       <!-- Sensor Device Base -->
                       <div class="glass-panel p-6">
                           <h2 class="text-sm font-bold text-slate-100 mb-6 flex items-center gap-2 uppercase tracking-widest"><i class="fa fa-cube text-emerald-400"></i><span data-i18n="sensor_base">网关传感器设备底座</span></h2>
+                          <p id="schemaNotice" class="hidden mb-4 text-[11px] text-amber-300 border border-amber-400/20 bg-amber-500/10 rounded-lg px-3 py-2"></p>
                           <div id="sensorGrid" class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-4">
                               <!-- Dynamic Device Tiles -->
                           </div>

--- a/frontend_v2_premium/ui.js
+++ b/frontend_v2_premium/ui.js
@@ -69,13 +69,29 @@ window.UI = (() => {
         }
     };
 
+    const renderSchemaNotice = () => {
+        const notice = document.getElementById('schemaNotice');
+        if (!notice) return;
+        if (window.API.isSchemaFallback && window.API.isSchemaFallback()) {
+            notice.classList.remove('hidden');
+            notice.textContent = 'Schema API unavailable, using fallback mapping (soil_modbus_02 / dht22).';
+            return;
+        }
+        notice.classList.add('hidden');
+    };
+
     const renderSensorGrid = (telemetry) => {
         const sensorGrid = document.getElementById('sensorGrid');
         if (!sensorGrid) return;
+        renderSchemaNotice();
 
         let data = Array.isArray(telemetry) ? telemetry : [];
 
         const uniqueSensors = Array.from(new Set(data.map((r) => r.sensor_id).filter(Boolean)));
+        if (!uniqueSensors.length) {
+            sensorGrid.innerHTML = `<div class="col-span-full text-center text-xs text-slate-500 py-8">${window.t('no_data')}</div>`;
+            return;
+        }
         sensorGrid.innerHTML = uniqueSensors
             .map((sid) => {
                 const latest = data.find((r) => r.sensor_id === sid);
@@ -307,6 +323,157 @@ window.UI = (() => {
         }
     };
 
+    const Upload = {
+        selectedFile: null,
+        activeDeviceId: '',
+
+        init: (deviceId = '') => {
+            Upload.activeDeviceId = (deviceId || localStorage.getItem('device_id') || '').trim();
+            const fileInput = document.getElementById('mobileUploadInput');
+            const pickBtn = document.getElementById('mobileUploadPickBtn');
+            const clearBtn = document.getElementById('mobileUploadClearBtn');
+            const submitBtn = document.getElementById('mobileUploadSubmitBtn');
+            if (!fileInput || !pickBtn || !submitBtn) return;
+
+            pickBtn.addEventListener('click', () => fileInput.click());
+            fileInput.addEventListener('change', () => {
+                const [file] = fileInput.files || [];
+                Upload.selectedFile = file || null;
+                Upload.renderSelectedFile();
+            });
+            if (clearBtn) {
+                clearBtn.addEventListener('click', () => {
+                    Upload.selectedFile = null;
+                    fileInput.value = '';
+                    Upload.setProgress(0);
+                    Upload.renderSelectedFile();
+                    Upload.setStatus('No image selected.', 'idle');
+                });
+            }
+            submitBtn.addEventListener('click', () => Upload.submit());
+            Upload.renderSelectedFile();
+            Upload.setStatus('Ready for mobile camera upload.', 'idle');
+        },
+
+        setStatus: (message, level = 'idle') => {
+            const statusEl = document.getElementById('mobileUploadStatus');
+            if (!statusEl) return;
+            const palette = {
+                idle: 'text-slate-400',
+                loading: 'text-emerald-300',
+                success: 'text-emerald-400',
+                error: 'text-rose-400',
+                warn: 'text-amber-300',
+            };
+            statusEl.className = `text-[11px] ${palette[level] || palette.idle}`;
+            statusEl.textContent = message;
+        },
+
+        setProgress: (value) => {
+            const bar = document.getElementById('mobileUploadProgressBar');
+            const label = document.getElementById('mobileUploadProgressText');
+            const v = Math.max(0, Math.min(100, Number(value) || 0));
+            if (bar) bar.style.width = `${v}%`;
+            if (label) label.textContent = `${v}%`;
+        },
+
+        renderSelectedFile: () => {
+            const nameEl = document.getElementById('mobileUploadFileName');
+            const preview = document.getElementById('mobileUploadPreview');
+            const emptyState = document.getElementById('mobileUploadPreviewEmpty');
+            const submitBtn = document.getElementById('mobileUploadSubmitBtn');
+            const file = Upload.selectedFile;
+            if (nameEl) {
+                if (file) {
+                    const mb = (file.size / (1024 * 1024)).toFixed(2);
+                    nameEl.textContent = `${file.name} (${mb} MB)`;
+                } else {
+                    nameEl.textContent = 'No image selected';
+                }
+            }
+            if (submitBtn) submitBtn.disabled = !file;
+            if (!preview || !emptyState) return;
+            if (!file) {
+                preview.src = '';
+                preview.classList.add('hidden');
+                emptyState.classList.remove('hidden');
+                return;
+            }
+            const blobUrl = URL.createObjectURL(file);
+            preview.src = blobUrl;
+            preview.onload = () => URL.revokeObjectURL(blobUrl);
+            preview.classList.remove('hidden');
+            emptyState.classList.add('hidden');
+        },
+
+        resolveTag: () => {
+            const now = new Date().toISOString();
+            let deviceId = (localStorage.getItem('device_id') || Upload.activeDeviceId || '').trim();
+            let location = '';
+            let cropType = '';
+            let farmNote = '';
+
+            const allDevices = HomePositioning.devicesData?.devices || [];
+            let pickedDevice = null;
+            if (deviceId) {
+                pickedDevice = allDevices.find((d) => d.device_id === deviceId) || null;
+            }
+            if (!pickedDevice) {
+                pickedDevice = allDevices.find((d) => {
+                    if (HomePositioning.selectedCropType && d.crop_type !== HomePositioning.selectedCropType) return false;
+                    if (HomePositioning.selectedLocation && d.location !== HomePositioning.selectedLocation) return false;
+                    return true;
+                }) || allDevices[0] || null;
+            }
+            if (pickedDevice) {
+                deviceId = pickedDevice.device_id || deviceId;
+                location = pickedDevice.location || '';
+                cropType = pickedDevice.crop_type || '';
+                farmNote = pickedDevice.farm_note || '';
+                localStorage.setItem('device_id', deviceId);
+            }
+            return {
+                device_id: deviceId,
+                ts: now,
+                location,
+                crop_type: cropType,
+                farm_note: farmNote,
+            };
+        },
+
+        submit: async () => {
+            if (!Upload.selectedFile) {
+                Upload.setStatus('Please select an image first.', 'warn');
+                return;
+            }
+            const submitBtn = document.getElementById('mobileUploadSubmitBtn');
+            if (submitBtn) submitBtn.disabled = true;
+            Upload.setProgress(0);
+            const tag = Upload.resolveTag();
+            if (!tag.device_id) {
+                Upload.setStatus('No device_id found. Open page with ?device_id=... or register device first.', 'error');
+                if (submitBtn) submitBtn.disabled = false;
+                return;
+            }
+            Upload.setStatus(`Uploading for ${tag.device_id} ...`, 'loading');
+            try {
+                const result = await window.API.uploadImage({
+                    file: Upload.selectedFile,
+                    tag,
+                    onProgress: (v) => Upload.setProgress(v),
+                });
+                Upload.setStatus(`Upload success: ${result.upload_id || 'accepted'}`, 'success');
+                if (window.APP && typeof window.APP.refreshNow === 'function') {
+                    await window.APP.refreshNow();
+                }
+            } catch (err) {
+                Upload.setStatus(`Upload failed: ${err.message || err}`, 'error');
+            } finally {
+                if (submitBtn) submitBtn.disabled = !Upload.selectedFile;
+            }
+        },
+    };
+
     const Charts = {
         chartInstances: new Map(),
         selectedCrop: null,
@@ -363,7 +530,9 @@ window.UI = (() => {
             const schema = window.API.getSchema();
             const sensorList = document.getElementById('sensorSelectionList');
             if (sensorList) {
-                let sids = Array.from(schema.keys()).filter(sid => sid !== 'mq7' && sid !== 'pcf8591');
+                const telemetrySensors = Array.from(new Set(window.API.getTelemetry().map((r) => r.sensor_id).filter(Boolean)));
+                let sids = Array.from(new Set([...schema.keys(), ...telemetrySensors]));
+                sids.sort();
                 sensorList.innerHTML = sids.map(sid => `
                     <label class="sensor-pill cursor-pointer group">
                         <input type="checkbox" value="${sid}" class="hidden peer" checked />
@@ -540,10 +709,34 @@ window.UI = (() => {
                     .filter((r) => r.sensor_id === sid)
                     .sort((a, b) => new Date(a.ts || 0).getTime() - new Date(b.ts || 0).getTime());
                 const schema = window.API.getSchema().get(sid);
-                if (!schema || sensorData.length === 0) return;
+                if (sensorData.length === 0) return;
 
-                schema.fields.forEach((fieldSpec, fieldName) => {
-                    const numericTypes = ['number', 'float', 'f32', 'f64', 'u8', 'u16', 'u32', 'i32'];
+                let fieldSpecs = [];
+                if (schema && schema.fields instanceof Map && schema.fields.size > 0) {
+                    fieldSpecs = Array.from(schema.fields.entries()).map(([fieldName, fieldSpec]) => ({
+                        fieldName,
+                        fieldSpec,
+                    }));
+                } else {
+                    const inferred = new Set();
+                    sensorData.forEach((row) => {
+                        Object.entries(row?.fields || {}).forEach(([fieldName, value]) => {
+                            if (!Number.isFinite(Number(value))) return;
+                            inferred.add(fieldName);
+                        });
+                    });
+                    fieldSpecs = Array.from(inferred).map((fieldName) => ({
+                        fieldName,
+                        fieldSpec: {
+                            label: fieldName,
+                            unit: '',
+                            data_type: 'f64',
+                        },
+                    }));
+                }
+
+                fieldSpecs.forEach(({ fieldName, fieldSpec }) => {
+                    const numericTypes = ['number', 'float', 'f32', 'f64', 'u8', 'u16', 'u32', 'u64', 'i32', 'i64'];
                     if (!numericTypes.includes(`${fieldSpec.data_type || ''}`.toLowerCase())) return;
 
                     const points = sensorData
@@ -848,6 +1041,7 @@ window.UI = (() => {
         openSensorDetail,
         openImagePreview,
         HomePositioning,
+        Upload,
         Charts,
         Health,
         setEnvChart: (c) => envChart = c,


### PR DESCRIPTION
## What this PR does
Implements the next slice of Discuss #6 execution for `frontend_v2_premium`:

1. Adds a real mobile image upload flow to Cloud API
- Camera/album picker UI on Home view
- Upload progress bar + status text
- Retry and timeout handling on weak networks
- Uses real `POST /api/v1/image/upload` (multipart) with real tags (`device_id/ts/location/crop_type/farm_note`)
- Refreshes dashboard data after successful upload

2. Adds schema fallback and warning for multi-sensor rendering
- `GET /api/v1/sensor/schema` failure now falls back to built-in minimal schema (`soil_modbus_02`, `dht22`)
- UI shows fallback notice banner when schema API is unavailable
- Chart sensor selection removes hardcoded sensor exclusions and derives from schema + live telemetry

3. Improves multi-sensor chart resilience
- If schema lacks a sensor, chart still infers numeric fields from telemetry data and renders true data (no mock)

## Files changed
- `frontend_v2_premium/api.js`
- `frontend_v2_premium/app.js`
- `frontend_v2_premium/index.html`
- `frontend_v2_premium/ui.js`

## Validation run
- `node --check frontend_v2_premium/api.js`
- `node --check frontend_v2_premium/ui.js`
- `node --check frontend_v2_premium/app.js`

## Issue alignment
- advances #61 (mobile upload chain)
- advances #67 (schema-driven multi-sensor adaptation)
