### PR TITLE
Frontend: decouple runtime constants for telemetry/upload

### DIFF
--- a/cloud/src/image_upload.rs
+++ b/cloud/src/image_upload.rs
@@ -70,6 +70,15 @@ pub(crate) fn parse_tag(query: &HashMap<String, String>) -> Result<ImageUploadTa
     let location = query.get("location").cloned().unwrap_or_default();
     let crop_type = query.get("crop_type").cloned().unwrap_or_default();
     let farm_note = query.get("farm_note").cloned().unwrap_or_default();
+    let capture_mode = query
+        .get("capture_mode")
+        .map(|v| v.trim().to_ascii_lowercase())
+        .filter(|v| !v.is_empty());
+    let capture_input = query
+        .get("capture_input")
+        .map(|v| v.trim().to_ascii_lowercase())
+        .filter(|v| !v.is_empty());
+    let farm_note = merge_capture_marker(farm_note, capture_mode.as_deref(), capture_input.as_deref());
 
     Ok(ImageUploadTag {
         device_id,
@@ -78,6 +87,33 @@ pub(crate) fn parse_tag(query: &HashMap<String, String>) -> Result<ImageUploadTa
         crop_type,
         farm_note,
     })
+}
+
+fn merge_capture_marker(base_note: String, capture_mode: Option<&str>, capture_input: Option<&str>) -> String {
+    let Some(mode) = capture_mode else {
+        return base_note;
+    };
+    let normalized_mode = if mode == "manual" || mode == "auto" {
+        mode
+    } else {
+        "auto"
+    };
+    let normalized_input = capture_input.unwrap_or("unknown");
+    let marker = format!("capture_mode={normalized_mode};capture_input={normalized_input}");
+    let trimmed = base_note.trim();
+    if trimmed.is_empty() {
+        return marker;
+    }
+    if trimmed.contains("capture_mode=") {
+        return trimmed
+            .split('|')
+            .map(str::trim)
+            .filter(|part| !part.starts_with("capture_mode="))
+            .chain(std::iter::once(marker.as_str()))
+            .collect::<Vec<_>>()
+            .join(" | ");
+    }
+    format!("{trimmed} | {marker}")
 }
 
 pub(crate) fn parse_multipart_file(

--- a/frontend_v2_premium/api.js
+++ b/frontend_v2_premium/api.js
@@ -3,10 +3,14 @@
  */
 
 window.API = (() => {
-    const GATEWAY_STALE_MS = 5 * 60 * 1000;
-    const DEFAULT_LIMIT = 300;
-    const DEFAULT_UPLOAD_RETRIES = 2;
-    const DEFAULT_UPLOAD_TIMEOUT_MS = 45000;
+    const runtime = window.RUNTIME_CONFIG || {};
+    const telemetryCfg = runtime.telemetry || {};
+    const uploadCfg = runtime.imageUpload || {};
+    const GATEWAY_STALE_MS = Number(telemetryCfg.gatewayStaleMs) || 5 * 60 * 1000;
+    const DEFAULT_LIMIT = Number(telemetryCfg.defaultLimit) || 300;
+    const HISTORY_MAX_LIMIT = Number(telemetryCfg.historyMaxLimit) || 1000;
+    const DEFAULT_UPLOAD_RETRIES = Number(uploadCfg.retries);
+    const DEFAULT_UPLOAD_TIMEOUT_MS = Number(uploadCfg.timeoutMs);
     const schemaBySensor = new Map();
     let schemaSource = 'remote';
     let telemetryRecords = [];
@@ -213,7 +217,7 @@ window.API = (() => {
                 device_id: id,
                 start_time: start.toISOString(),
                 end_time: endExclusive.toISOString(),
-                limit: Math.max(DEFAULT_LIMIT, Math.min(limit, 1000)),
+                limit: Math.max(DEFAULT_LIMIT, Math.min(limit, HISTORY_MAX_LIMIT)),
             });
             return fetchWithRetry(url);
         });
@@ -328,7 +332,13 @@ window.API = (() => {
             xhr.send(form);
         });
 
-    const uploadImage = async ({ file, tag, retries = DEFAULT_UPLOAD_RETRIES, timeoutMs = DEFAULT_UPLOAD_TIMEOUT_MS, onProgress }) => {
+    const uploadImage = async ({
+        file,
+        tag,
+        retries = Number.isFinite(DEFAULT_UPLOAD_RETRIES) ? DEFAULT_UPLOAD_RETRIES : 2,
+        timeoutMs = Number.isFinite(DEFAULT_UPLOAD_TIMEOUT_MS) ? DEFAULT_UPLOAD_TIMEOUT_MS : 45000,
+        onProgress,
+    }) => {
         const deviceId = `${tag?.device_id || ''}`.trim();
         if (!deviceId) throw new Error('device_id is required for upload');
         const preparedFile = await maybeConvertForUpload(file);

--- a/frontend_v2_premium/api.js
+++ b/frontend_v2_premium/api.js
@@ -297,6 +297,8 @@ window.API = (() => {
             location: tag?.location || '',
             crop_type: tag?.crop_type || '',
             farm_note: tag?.farm_note || '',
+            capture_mode: tag?.capture_mode || '',
+            capture_input: tag?.capture_input || '',
         });
 
     const uploadImageOnce = ({ file, tag, timeoutMs, onProgress }) =>

--- a/frontend_v2_premium/app.js
+++ b/frontend_v2_premium/app.js
@@ -4,6 +4,9 @@
  */
 
 window.onload = async () => {
+    const runtime = window.RUNTIME_CONFIG || {};
+    const telemetryCfg = runtime.telemetry || {};
+    const refreshMs = Number(telemetryCfg.chartRefreshMs) || 15000;
     const params = new URLSearchParams(window.location.search);
     let activeDeviceId = (params.get('device_id') || localStorage.getItem('device_id') || '').trim();
     if (activeDeviceId) localStorage.setItem('device_id', activeDeviceId);
@@ -38,7 +41,7 @@ window.onload = async () => {
     setInterval(() => {
         activeDeviceId = (localStorage.getItem('device_id') || activeDeviceId || '').trim();
         updateAppLoop(activeDeviceId);
-    }, 15000);
+    }, refreshMs);
 
     // Initial Resize
     window.UI.switchView('view-home');

--- a/frontend_v2_premium/index.html
+++ b/frontend_v2_premium/index.html
@@ -582,6 +582,7 @@
 
 
   <script src="i18n.js"></script>
+  <script src="runtime-config.js"></script>
   <script src="api.js"></script>
   <script src="ui.js"></script>
   <script src="chat.js"></script>

--- a/frontend_v2_premium/index.html
+++ b/frontend_v2_premium/index.html
@@ -254,10 +254,14 @@
                           <div class="glass-panel p-6">
                               <h2 class="text-sm font-bold text-slate-100 mb-4 flex items-center gap-2 uppercase tracking-widest"><i class="fa fa-camera text-blue-400"></i><span>手机图传上传</span></h2>
                               <p class="text-[11px] text-slate-400 mb-4">仅真实链路：图片将通过 <span class="font-mono text-emerald-300">/api/v1/image/upload</span> 上传并触发 AI 入库。</p>
-                              <input id="mobileUploadInput" type="file" accept="image/*,.jpg,.jpeg,.png,.heic,.heif" capture="environment" class="hidden" />
-                              <div class="grid grid-cols-1 md:grid-cols-[1fr_auto_auto] gap-2 mb-3">
-                                  <button id="mobileUploadPickBtn" class="px-3 py-2 rounded-lg bg-white/10 border border-white/15 text-xs text-slate-100 hover:bg-white/20 transition-all">
-                                      <i class="fa fa-camera mr-1"></i>拍照 / 选图
+                              <input id="mobileUploadCameraInput" type="file" accept="image/*,.jpg,.jpeg,.png,.heic,.heif" capture="environment" class="hidden" />
+                              <input id="mobileUploadFileInput" type="file" accept="image/*,.jpg,.jpeg,.png,.heic,.heif" class="hidden" />
+                              <div class="mobile-upload-actions mb-3">
+                                  <button id="mobileUploadCameraBtn" class="px-3 py-2 rounded-lg bg-sky-500/20 border border-sky-400/30 text-xs text-sky-100 hover:bg-sky-500/30 transition-all">
+                                      <i class="fa fa-camera mr-1"></i>手机拍照
+                                  </button>
+                                  <button id="mobileUploadAlbumBtn" class="px-3 py-2 rounded-lg bg-white/10 border border-white/15 text-xs text-slate-100 hover:bg-white/20 transition-all">
+                                      <i class="fa fa-image mr-1"></i>相册图片
                                   </button>
                                   <button id="mobileUploadClearBtn" class="px-3 py-2 rounded-lg bg-black/30 border border-white/10 text-xs text-slate-300 hover:text-white transition-all">清空</button>
                                   <button id="mobileUploadSubmitBtn" class="px-3 py-2 rounded-lg bg-emerald-600/80 border border-emerald-400/30 text-xs text-white hover:bg-emerald-500 disabled:opacity-50 disabled:cursor-not-allowed transition-all" disabled>上传</button>
@@ -278,7 +282,7 @@
 
                           <div class="glass-panel p-6 flex flex-col">
                               <h2 class="text-sm font-bold text-slate-100 mb-6 flex items-center gap-2 uppercase tracking-widest"><i class="fa fa-microchip text-rose-400"></i><span data-i18n="ai_feedback">视觉 AI 反馈</span></h2>
-                              <div id="aiDiagnosisContainer" class="flex-1 space-y-4 overflow-y-auto max-h-[250px] pr-2">
+                              <div id="aiDiagnosisContainer" class="diagnosis-scroll flex-1 space-y-4 overflow-y-auto max-h-[360px] pr-2">
                                   <!-- Diagnosis Cards -->
                               </div>
                           </div>

--- a/frontend_v2_premium/runtime-config.js
+++ b/frontend_v2_premium/runtime-config.js
@@ -1,0 +1,37 @@
+/**
+ * Frontend runtime config (DB-first / real-data only).
+ * Override via `window.AI_AG_RUNTIME_CONFIG` before this script loads.
+ */
+(function initRuntimeConfig() {
+    const defaults = {
+        telemetry: {
+            gatewayStaleMs: 5 * 60 * 1000,
+            defaultLimit: 300,
+            historyMaxLimit: 1000,
+            chartRefreshMs: 15000,
+            chartPruneWindowMs: 7 * 24 * 3600 * 1000,
+        },
+        imageUpload: {
+            retries: 2,
+            timeoutMs: 45000,
+        },
+    };
+
+    const deepMerge = (base, extra) => {
+        const out = { ...base };
+        Object.keys(extra || {}).forEach((key) => {
+            const bv = base?.[key];
+            const ev = extra[key];
+            if (bv && typeof bv === 'object' && !Array.isArray(bv) && ev && typeof ev === 'object' && !Array.isArray(ev)) {
+                out[key] = deepMerge(bv, ev);
+            } else {
+                out[key] = ev;
+            }
+        });
+        return out;
+    };
+
+    const merged = deepMerge(defaults, window.AI_AG_RUNTIME_CONFIG || {});
+    window.RUNTIME_CONFIG = Object.freeze(merged);
+})();
+

--- a/frontend_v2_premium/styles.css
+++ b/frontend_v2_premium/styles.css
@@ -533,6 +533,16 @@
   background: rgba(16, 185, 129, 0.12);
 }
 
+.mobile-upload-actions {
+  display: grid;
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+  gap: 0.5rem;
+}
+
+.diagnosis-scroll {
+  scrollbar-gutter: stable;
+}
+
 @media (max-width: 1024px) {
   :root {
     --panel-left-w: 320px;
@@ -662,6 +672,10 @@
     width: auto !important;
     max-width: none !important;
   }
+
+  .mobile-upload-actions {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
 }
 
 @media (max-width: 640px) {
@@ -705,5 +719,13 @@
     border-right: none !important;
     padding-left: 0 !important;
     padding-right: 0 !important;
+  }
+
+  .mobile-upload-actions {
+    grid-template-columns: 1fr;
+  }
+
+  .diagnosis-scroll {
+    max-height: 420px !important;
   }
 }

--- a/frontend_v2_premium/ui.js
+++ b/frontend_v2_premium/ui.js
@@ -185,6 +185,52 @@ window.UI = (() => {
         `;
     };
 
+    const inferCaptureMode = (row) => {
+        const explicit = `${row?.capture_mode || ''}`.trim().toLowerCase();
+        if (explicit === 'manual' || explicit === 'auto') return explicit;
+        const note = `${row?.farm_note || ''}`.toLowerCase();
+        if (note.includes('capture_mode=manual')) return 'manual';
+        if (note.includes('capture_mode=auto')) return 'auto';
+        return 'auto';
+    };
+
+    const renderDiagnosisCard = (r, captureMode) => {
+        const state = r.upload_status || 'stored';
+        const diseaseRate = typeof r.disease_rate === 'number' ? `${(r.disease_rate * 100).toFixed(1)}%` : '-';
+        const card =
+            state === 'failed'
+                ? { bg: 'bg-rose-500/10', text: 'text-rose-400', border: 'border-rose-500/20', badge: 'FAILED' }
+                : state === 'inferred'
+                    ? { bg: 'bg-emerald-500/10', text: 'text-emerald-400', border: 'border-emerald-500/20', badge: 'INFERRED' }
+                    : { bg: 'bg-white/5', text: 'text-slate-400', border: 'border-white/5', badge: 'STORED' };
+        const modeClass = captureMode === 'manual'
+            ? 'bg-sky-500/15 text-sky-300 border-sky-400/30'
+            : 'bg-violet-500/15 text-violet-300 border-violet-400/30';
+        const modeLabel = captureMode === 'manual' ? 'MANUAL' : 'AUTO';
+        const imgUrl = r.upload_id
+            ? `/api/v1/image/file?upload_id=${encodeURIComponent(r.upload_id)}`
+            : (r.saved_path ? `/api/v1/image/file?saved_path=${encodeURIComponent(r.saved_path)}` : '');
+        const safeUploadId = `${r.upload_id || ''}`.replace(/'/g, "\\'");
+        return `
+            <div class="p-4 border ${card.border} ${card.bg} rounded-xl mb-3">
+                <div class="flex justify-between items-start mb-2 gap-2">
+                    <p class="text-[10px] text-slate-400 font-mono">${formatDate(r.captured_at || r.ts)}</p>
+                    <div class="flex items-center gap-1.5">
+                        <span class="text-[9px] uppercase font-bold px-2 py-0.5 border rounded-full ${modeClass}">${modeLabel}</span>
+                        <span class="text-[10px] ${card.text} uppercase font-bold">${card.badge}</span>
+                    </div>
+                </div>
+                <h4 class="text-sm font-bold text-white mb-1.5">${r.predicted_class || window.t('processing')}</h4>
+                <p class="text-[11px] text-slate-300 mb-2">${window.t('disease_rate')}: <span class="${card.text} font-semibold">${diseaseRate}</span></p>
+                <div class="h-28 w-full bg-black/30 rounded-lg overflow-hidden border border-white/10 cursor-pointer" onclick="UI.openImagePreview('${imgUrl}', '${safeUploadId}')">
+                    ${imgUrl
+                        ? `<img src="${imgUrl}" alt="${safeUploadId}" class="w-full h-full object-cover" onerror="this.parentElement.innerHTML='<div class=&quot;w-full h-full flex items-center justify-center text-xs text-slate-500&quot;>${window.t('img_fail')}</div>';" />`
+                        : '<div class="w-full h-full flex items-center justify-center text-xs text-slate-500">' + window.t('no_data') + '</div>'}
+                </div>
+            </div>
+        `;
+    };
+
     const renderDiagnosis = (imageUploads) => {
         const aiContainer = document.getElementById('aiDiagnosisContainer');
         if (!aiContainer) return;
@@ -196,37 +242,27 @@ window.UI = (() => {
             return;
         }
 
-        aiContainer.innerHTML = latestImageUploads
-            .map((r) => {
-                const state = r.upload_status || 'stored';
-                const diseaseRate = typeof r.disease_rate === 'number' ? `${(r.disease_rate * 100).toFixed(1)}%` : '-';
-                const card =
-                    state === 'failed'
-                        ? { bg: 'bg-rose-500/10', text: 'text-rose-400', border: 'border-rose-500/20', badge: 'FAILED' }
-                        : state === 'inferred'
-                            ? { bg: 'bg-emerald-500/10', text: 'text-emerald-400', border: 'border-emerald-500/20', badge: 'INFERRED' }
-                            : { bg: 'bg-white/5', text: 'text-slate-400', border: 'border-white/5', badge: 'STORED' };
-                const imgUrl = r.upload_id
-                    ? `/api/v1/image/file?upload_id=${encodeURIComponent(r.upload_id)}`
-                    : (r.saved_path ? `/api/v1/image/file?saved_path=${encodeURIComponent(r.saved_path)}` : '');
-                const safeUploadId = `${r.upload_id || ''}`.replace(/'/g, "\\'");
-                return `
-                    <div class="p-4 border ${card.border} ${card.bg} rounded-xl mb-4">
-                        <div class="flex justify-between items-start mb-2">
-                            <p class="text-[10px] text-slate-400 font-mono">${formatDate(r.captured_at || r.ts)}</p>
-                            <span class="text-[10px] ${card.text} uppercase font-bold">${card.badge}</span>
-                        </div>
-                        <h4 class="text-sm font-bold text-white mb-2">${r.predicted_class || window.t('processing')}</h4>
-                        <p class="text-[11px] text-slate-300 mb-2">${window.t('disease_rate')}: <span class="${card.text} font-semibold">${diseaseRate}</span></p>
-                        <div class="h-28 w-full bg-black/30 rounded-lg overflow-hidden border border-white/10 cursor-pointer" onclick="UI.openImagePreview('${imgUrl}', '${safeUploadId}')">
-                            ${imgUrl
-                                ? `<img src="${imgUrl}" alt="${safeUploadId}" class="w-full h-full object-cover" onerror="this.parentElement.innerHTML='<div class=&quot;w-full h-full flex items-center justify-center text-xs text-slate-500&quot;>${window.t('img_fail')}</div>';" />`
-                                : '<div class="w-full h-full flex items-center justify-center text-xs text-slate-500">' + window.t('no_data') + '</div>'}
-                        </div>
-                    </div>
-                `;
-            })
-            .join('');
+        const manualRows = latestImageUploads.filter((row) => inferCaptureMode(row) === 'manual');
+        const autoRows = latestImageUploads.filter((row) => inferCaptureMode(row) !== 'manual');
+        const sectionHtml = (title, icon, rows, mode) => `
+            <div class="border border-white/10 rounded-xl p-3 bg-black/20">
+                <div class="flex items-center justify-between mb-2">
+                    <h4 class="text-[10px] uppercase tracking-widest font-bold text-slate-200 flex items-center gap-2">
+                        <i class="fa ${icon}"></i>${title}
+                    </h4>
+                    <span class="text-[10px] text-slate-400 font-mono">${rows.length}</span>
+                </div>
+                ${
+                    rows.length
+                        ? rows.slice(0, 6).map((row) => renderDiagnosisCard(row, mode)).join('')
+                        : `<div class="text-[11px] text-slate-500 p-3 text-center">${window.t('no_data')}</div>`
+                }
+            </div>
+        `;
+        aiContainer.innerHTML = [
+            sectionHtml('Manual Capture', 'fa-mobile', manualRows, 'manual'),
+            sectionHtml('Auto Pipeline', 'fa-random', autoRows, 'auto'),
+        ].join('');
     };
 
     const openImagePreview = (url, title = '') => {
@@ -326,25 +362,55 @@ window.UI = (() => {
     const Upload = {
         selectedFile: null,
         activeDeviceId: '',
+        selectedInputType: 'album',
+        isMobileClient: false,
 
         init: (deviceId = '') => {
             Upload.activeDeviceId = (deviceId || localStorage.getItem('device_id') || '').trim();
-            const fileInput = document.getElementById('mobileUploadInput');
-            const pickBtn = document.getElementById('mobileUploadPickBtn');
+            const cameraInput = document.getElementById('mobileUploadCameraInput');
+            const fileInput = document.getElementById('mobileUploadFileInput');
+            const cameraBtn = document.getElementById('mobileUploadCameraBtn');
+            const albumBtn = document.getElementById('mobileUploadAlbumBtn');
             const clearBtn = document.getElementById('mobileUploadClearBtn');
             const submitBtn = document.getElementById('mobileUploadSubmitBtn');
-            if (!fileInput || !pickBtn || !submitBtn) return;
+            if (!cameraInput || !fileInput || !cameraBtn || !albumBtn || !submitBtn) return;
 
-            pickBtn.addEventListener('click', () => fileInput.click());
-            fileInput.addEventListener('change', () => {
-                const [file] = fileInput.files || [];
+            Upload.isMobileClient = /Android|iPhone|iPad|iPod|Mobile/i.test(navigator.userAgent || '')
+                || window.matchMedia('(max-width: 900px)').matches;
+            if (!Upload.isMobileClient) {
+                cameraBtn.disabled = true;
+                cameraBtn.classList.add('opacity-50', 'cursor-not-allowed');
+                cameraBtn.title = 'Camera capture is mobile-only';
+            }
+
+            const setFileFromInput = (inputEl, inputType) => {
+                Upload.selectedInputType = inputType;
+                const [file] = inputEl.files || [];
                 Upload.selectedFile = file || null;
                 Upload.renderSelectedFile();
+            };
+
+            cameraBtn.addEventListener('click', () => {
+                if (!Upload.isMobileClient) {
+                    Upload.setStatus('拍照按钮仅支持手机端，请改用“相册图片”。', 'warn');
+                    return;
+                }
+                Upload.selectedInputType = 'camera';
+                cameraInput.click();
             });
+            albumBtn.addEventListener('click', () => {
+                Upload.selectedInputType = 'album';
+                fileInput.click();
+            });
+            cameraInput.addEventListener('change', () => setFileFromInput(cameraInput, 'camera'));
+            fileInput.addEventListener('change', () => setFileFromInput(fileInput, 'album'));
+
             if (clearBtn) {
                 clearBtn.addEventListener('click', () => {
                     Upload.selectedFile = null;
                     fileInput.value = '';
+                    cameraInput.value = '';
+                    Upload.selectedInputType = 'album';
                     Upload.setProgress(0);
                     Upload.renderSelectedFile();
                     Upload.setStatus('No image selected.', 'idle');
@@ -352,7 +418,7 @@ window.UI = (() => {
             }
             submitBtn.addEventListener('click', () => Upload.submit());
             Upload.renderSelectedFile();
-            Upload.setStatus('Ready for mobile camera upload.', 'idle');
+            Upload.setStatus(Upload.isMobileClient ? 'Ready for mobile camera upload.' : 'Desktop mode: album upload enabled.', 'idle');
         },
 
         setStatus: (message, level = 'idle') => {
@@ -386,7 +452,8 @@ window.UI = (() => {
             if (nameEl) {
                 if (file) {
                     const mb = (file.size / (1024 * 1024)).toFixed(2);
-                    nameEl.textContent = `${file.name} (${mb} MB)`;
+                    const inputMode = Upload.selectedInputType === 'camera' ? 'camera' : 'album';
+                    nameEl.textContent = `${file.name} (${mb} MB, ${inputMode})`;
                 } else {
                     nameEl.textContent = 'No image selected';
                 }
@@ -404,6 +471,17 @@ window.UI = (() => {
             preview.onload = () => URL.revokeObjectURL(blobUrl);
             preview.classList.remove('hidden');
             emptyState.classList.add('hidden');
+        },
+
+        buildTaggedFarmNote: (baseNote) => {
+            const note = `${baseNote || ''}`.trim();
+            const inputMode = Upload.selectedInputType === 'camera' ? 'camera' : 'album';
+            const marker = `capture_mode=manual;capture_input=${inputMode}`;
+            if (!note) return marker;
+            if (note.includes('capture_mode=')) {
+                return note.replace(/capture_mode=[^;|\s]+(;capture_input=[^;|\s]+)?/i, marker);
+            }
+            return `${note} | ${marker}`;
         },
 
         resolveTag: () => {
@@ -432,12 +510,15 @@ window.UI = (() => {
                 farmNote = pickedDevice.farm_note || '';
                 localStorage.setItem('device_id', deviceId);
             }
+            farmNote = Upload.buildTaggedFarmNote(farmNote);
             return {
                 device_id: deviceId,
                 ts: now,
                 location,
                 crop_type: cropType,
                 farm_note: farmNote,
+                capture_mode: 'manual',
+                capture_input: Upload.selectedInputType === 'camera' ? 'camera' : 'album',
             };
         },
 

--- a/frontend_v2_premium/ui.js
+++ b/frontend_v2_premium/ui.js
@@ -646,12 +646,13 @@ window.UI = (() => {
                 const queryEnd = endTime ? new Date(endTime) : new Date();
                 // Keep devices registered within 7 days before the end of the query window.
                 // This skips obviously stale shadow IDs without affecting real multi-device deployments.
-                const PRUNE_WINDOW_MS = 7 * 24 * 3600 * 1000;
+                const runtime = window.RUNTIME_CONFIG || {};
+                const pruneWindowMs = Number(runtime?.telemetry?.chartPruneWindowMs) || 7 * 24 * 3600 * 1000;
                 const matchedDevices = Charts._devicesData.devices.filter(d => {
                     if (d.crop_type !== Charts.selectedCrop || d.location !== Charts.selectedLocation) return false;
                     if (!d.registered_at_epoch_sec) return true;
                     const registeredAt = d.registered_at_epoch_sec * 1000;
-                    return (queryEnd.getTime() - registeredAt) < PRUNE_WINDOW_MS;
+                    return (queryEnd.getTime() - registeredAt) < pruneWindowMs;
                 });
                 deviceIds = matchedDevices.map(d => d.device_id);
                 // If all were pruned (e.g. user queries very old data), fall back to all matches


### PR DESCRIPTION
## Summary
This is the next execution step after closing #59/#61/#67, advancing issue #49 (config decoupling) on `frontend_v2_premium`.

## Changes
- Added `frontend_v2_premium/runtime-config.js`
  - supports optional override via `window.AI_AG_RUNTIME_CONFIG`
  - exports merged `window.RUNTIME_CONFIG`
- Injected runtime config in `frontend_v2_premium/index.html`
- Replaced hardcoded constants with runtime-config values:
  - `gatewayStaleMs`
  - `defaultLimit`
  - `historyMaxLimit`
  - `chartRefreshMs`
  - `chartPruneWindowMs`
  - image upload `retries` and `timeoutMs`

## Why
Keeps frontend behavior configurable without code edits, and reduces hardcoded environment assumptions in line with #49.

## Validation
- `node --check frontend_v2_premium/runtime-config.js`
- `node --check frontend_v2_premium/api.js`
- `node --check frontend_v2_premium/ui.js`
- `node --check frontend_v2_premium/app.js`

## Issue
- advances #49 (partial)
