### PR TITLE
rollback(main): revert to c701e9f baseline (non-force)

### DIFF
--- a/cloud/scripts/openclaw_chat_adapter.py
+++ b/cloud/scripts/openclaw_chat_adapter.py
@@ -1,6 +1,10 @@
-
 #!/usr/bin/env python3
-"""
+"""OpenClaw Chat Adapter v2 — uses `openclaw agent --local` via subprocess.
+
+Speed: ~1.8s per turn .
+Multi-turn: adapter caches history, injects into prompt.
+Streaming: SSE char-by-char after reply received.
+Knowledge: loads AI-ag-agent-skill.md.
 
 JSON contract:
   Input:  {"message": "...", "context": {"current_vwc": 25.5, ...}, "session_id": "..."}

--- a/cloud/scripts/openclaw_chat_adapter.py
+++ b/cloud/scripts/openclaw_chat_adapter.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 """OpenClaw Chat Adapter v2 — uses `openclaw agent --local` via subprocess.
 
-Speed: ~1.8s per turn .
+Speed: ~1.8s per turn (vs 10+s before).
 Multi-turn: adapter caches history, injects into prompt.
 Streaming: SSE char-by-char after reply received.
 Knowledge: loads AI-ag-agent-skill.md.

--- a/frontend_v2_premium/chat.js
+++ b/frontend_v2_premium/chat.js
@@ -1,4 +1,12 @@
-
+/**
+ * Chat & Agent — SSE streaming, multi-turn, session-aware.
+ * Sends POST /api/v1/chat/stream (SSE) with /api/v1/chat fallback.
+ * Uses persistent session_id for multi-turn conversation on server side.
+ *
+ * JSON contract:
+ *   Input:  {message, context, session_id}
+ *   Output: {reply}
+ */
 window.CHAT = (() => {
     const SESSION_ID_KEY = 'agri_session_id';
 

--- a/frontend_v2_premium/styles.css
+++ b/frontend_v2_premium/styles.css
@@ -1,4 +1,3 @@
-
 @layer utilities {
   .glass { @apply bg-white/10 backdrop-blur-lg border border-white/20 shadow-xl; }
   .glass-panel { @apply bg-slate-800/70 backdrop-blur-xl border border-white/10 shadow-2xl rounded-2xl; }

--- a/frontend_v2_premium/ui.js
+++ b/frontend_v2_premium/ui.js
@@ -1,4 +1,6 @@
-
+/**
+ * UI & rendering module.
+ */
 window.UI = (() => {
     let envChart;
     let faultTrendChart;


### PR DESCRIPTION
## 回滚目标
将 `main` 逻辑回滚到提交 `c701e9f`（`refactor: chat adapter v2 + frontend streaming + multi-turn`）。

## 实现方式
由于仓库规则禁止对 `main` 强推，本 PR 采用 `revert` 方式撤销 `c701e9f` 之后的 5 个提交，达到等效回滚。

## 影响范围
- `cloud/scripts/openclaw_chat_adapter.py`
- `frontend_v2_premium/ui.js`
- `frontend_v2_premium/styles.css`
- `frontend_v2_premium/chat.js`