### PR TITLE
chore(config): complete cloud/service/dashboard decoupling for issue #49

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,6 +89,30 @@ pytest -q
 - 如仅需运行 AI 模块测试，可使用 `pytest -q tests`
 - `tests/test_infer_smoke.py` 依赖 `torch` 与 `torchvision`
 
+## Configuration-First Deployment Notes
+
+Use environment variables or deployment config files to switch environments.
+Do not hardcode a fixed server IP, serial path, or port in code.
+
+Recommended variables:
+
+- `CLOUD_BIND_ADDR` (example: `0.0.0.0:9000`)
+- `AI_PREDICT_URL` (example: `http://ai-engine:8000/api/v1/predict`)
+- `OPENCLAW_URL` (example: `http://openclaw:3000`)
+- `TOKEN_STORE_PATH`, `REGISTRY_PATH`, `TELEMETRY_STORE_PATH`
+- `IMAGE_STORE_PATH`, `IMAGE_INDEX_PATH`, `IMAGE_DB_ERROR_STORE_PATH`
+
+Gateway-side variables (WSL/edge):
+
+- `GATEWAY_CLOUD_TARGET`
+- `GATEWAY_BAUD_LIST`
+- `GATEWAY_MODBUS_PORT`
+- `GATEWAY_IMAGE_UPLOAD_URL` (or compose via gateway config)
+
+Acceptance rule:
+
+- Switch target environment by changing configuration only, without code edits.
+
 ## License
 
 本项目使用 MIT License，详见根目录 `LICENSE`。

--- a/cloud/.env.example
+++ b/cloud/.env.example
@@ -5,8 +5,16 @@
 # CLOUD_BIND_ADDR=0.0.0.0:9000
 
 # Database Configuration (Overrides config/sensors.toml)
-# DATABASE_URL=postgres://postgres:YOUR_DB_PASSWORD@127.0.0.1:55432/ai_agriculture
+# DATABASE_URL=postgres://postgres:CHANGE_ME@db:5432/ai_agriculture
 
 # AI Service Endpoints (Overrides config/sensors.toml)
-# AI_PREDICT_URL=http://127.0.0.1:8000/api/v1/predict
-# OPENCLAW_URL=http://127.0.0.1:3000
+# AI_PREDICT_URL=http://ai-engine:8000/api/v1/predict
+# OPENCLAW_URL=http://openclaw:3000
+
+# Local State Storage Overrides
+# TOKEN_STORE_PATH=state/token_store.json
+# REGISTRY_PATH=state/registry.json
+# TELEMETRY_STORE_PATH=state/telemetry.jsonl
+# IMAGE_STORE_PATH=state/image_uploads
+# IMAGE_INDEX_PATH=state/image_index.jsonl
+# IMAGE_DB_ERROR_STORE_PATH=state/image_upload_errors.jsonl

--- a/cloud/config/sensors.toml
+++ b/cloud/config/sensors.toml
@@ -9,9 +9,9 @@ registry_path = "state/registry.json"
 image_store_path = "state/image_uploads"
 image_index_path = "state/image_index.jsonl"
 image_db_error_store_path = "state/image_upload_errors.jsonl"
-database_url = "postgres://postgres:YOUR_DB_PASSWORD@127.0.0.1:55432/ai_agriculture"
-ai_predict_url = "http://127.0.0.1:8000/api/v1/predict"
-openclaw_url = "http://127.0.0.1:3000"
+database_url = "postgres://postgres:CHANGE_ME@db:5432/ai_agriculture"
+ai_predict_url = "http://ai-engine:8000/api/v1/predict"
+openclaw_url = "http://openclaw:3000"
 
 [[exact_payloads]]
 payload = "success"

--- a/cloud/dashboard/app.js
+++ b/cloud/dashboard/app.js
@@ -3,8 +3,20 @@ const deviceId = (params.get('device_id') || localStorage.getItem('device_id') |
 if (deviceId) localStorage.setItem('device_id', deviceId);
 document.getElementById('ctxDevice').textContent = `设备: ${deviceId || 'all'}`;
 
-const GATEWAY_STALE_MS = 5 * 60 * 1000;
-const DISEASE_THRESHOLD = 0.5;
+const runtime = window.DASHBOARD_CONFIG || {};
+const telemetryCfg = runtime.telemetry || {};
+const sensorsCfg = runtime.sensors || {};
+
+const GATEWAY_STALE_MS = Number(telemetryCfg.gatewayStaleMs) || 5 * 60 * 1000;
+const DISEASE_THRESHOLD = Number(telemetryCfg.diseaseThreshold) || 0.5;
+const REFRESH_MS = Number(telemetryCfg.refreshMs) || 15000;
+const TELEMETRY_LIMIT = Number(telemetryCfg.telemetryLimit) || 300;
+const IMAGE_LIMIT = Number(telemetryCfg.imageLimit) || 50;
+const TELEMETRY_TABLE_ROWS = Number(telemetryCfg.telemetryTableRows) || 10;
+const IMAGE_TABLE_ROWS = Number(telemetryCfg.imageTableRows) || 10;
+const FERTILITY_SENSOR_ID = (sensorsCfg.fertilitySensorId || 'soil_modbus_02').trim();
+const FERTILITY_FIELD = (sensorsCfg.fertilityField || 'ec').trim();
+const FERTILITY_UNIT = (sensorsCfg.fertilityUnit || 'μS/cm').trim();
 
 let fertilityChart;
 let faultTrendChart;
@@ -170,9 +182,9 @@ function sensorFaultDevices(latestMap) {
 
 function fertilitySeries(telemetry) {
   const rows = telemetry
-    .filter(r => r.sensor_id === 'soil_modbus_02')
-    .map(r => ({ tsMs: Date.parse(r.ts || ''), ts: r.ts, ec: asNumber(r?.fields?.ec) }))
-    .filter(x => Number.isFinite(x.tsMs) && x.ec !== null)
+    .filter(r => r.sensor_id === FERTILITY_SENSOR_ID)
+    .map(r => ({ tsMs: Date.parse(r.ts || ''), ts: r.ts, value: asNumber(r?.fields?.[FERTILITY_FIELD]) }))
+    .filter(x => Number.isFinite(x.tsMs) && x.value !== null)
     .sort((a, b) => a.tsMs - b.tsMs);
   return rows;
 }
@@ -232,8 +244,8 @@ function fmtRate(value) {
 }
 
 async function loadData() {
-  const telemetryUrl = apiUrl('/api/v1/telemetry', { device_id: deviceId, limit: 300 });
-  const imageUrl = apiUrl('/api/v1/image/uploads', { device_id: deviceId, limit: 50 });
+  const telemetryUrl = apiUrl('/api/v1/telemetry', { device_id: deviceId, limit: TELEMETRY_LIMIT });
+  const imageUrl = apiUrl('/api/v1/image/uploads', { device_id: deviceId, limit: IMAGE_LIMIT });
   const [telemetry, imageUploads] = await Promise.all([
     fetchJson(telemetryUrl).catch(() => []),
     fetchJson(imageUrl).catch(() => [])
@@ -246,7 +258,7 @@ async function loadData() {
   const faultDeviceSet = new Set([...gatewaySet, ...sensorFault.devices]);
 
   const soilRows = fertilitySeries(telemetry);
-  const avgEc = soilRows.length ? (soilRows.reduce((sum, r) => sum + r.ec, 0) / soilRows.length) : null;
+  const avgEc = soilRows.length ? (soilRows.reduce((sum, r) => sum + r.value, 0) / soilRows.length) : null;
 
   const diseaseRates = imageUploads
     .map(r => fmtRate(r.disease_rate))
@@ -256,12 +268,12 @@ async function loadData() {
     : null;
 
   document.getElementById('valDeviceCount').textContent = latestMap.size || '-';
-  document.getElementById('valAvgEc').textContent = avgEc === null ? '-' : `${avgEc.toFixed(1)} μS/cm`;
+  document.getElementById('valAvgEc').textContent = avgEc === null ? '-' : `${avgEc.toFixed(1)} ${FERTILITY_UNIT}`;
   document.getElementById('valFaultDevices').textContent = faultDeviceSet.size || '0';
   document.getElementById('valAvgDiseaseRate').textContent = avgDiseaseRate === null ? '-' : `${(avgDiseaseRate * 100).toFixed(1)}%`;
 
   fertilityChart.data.labels = soilRows.map(r => formatTime(r.ts));
-  fertilityChart.data.datasets[0].data = soilRows.map(r => r.ec);
+  fertilityChart.data.datasets[0].data = soilRows.map(r => r.value);
   fertilityChart.update();
 
   const faultTrend = faultTrendSeries(telemetry, nowMs);
@@ -271,13 +283,15 @@ async function loadData() {
   faultTrendChart.update();
 
   const telemetryBody = document.getElementById('telemetryBody');
-  const telemetryRows = [...telemetry].sort((a, b) => Date.parse(b.ts || '') - Date.parse(a.ts || '')).slice(0, 10);
+  const telemetryRows = [...telemetry]
+    .sort((a, b) => Date.parse(b.ts || '') - Date.parse(a.ts || ''))
+    .slice(0, TELEMETRY_TABLE_ROWS);
   if (!telemetryRows.length) {
     telemetryBody.innerHTML = '<tr><td colspan="5" class="py-4 text-center text-gray-500">暂无数据</td></tr>';
   } else {
     telemetryBody.innerHTML = telemetryRows.map(row => {
       const device = row.device_id || '-';
-      const ec = asNumber(row?.fields?.ec);
+      const ec = asNumber(row?.fields?.[FERTILITY_FIELD]);
       const stale = gatewaySet.has(device);
       const sensorResult = detectSensorFault(row);
       let status = '正常';
@@ -286,7 +300,8 @@ async function loadData() {
       if (stale) {
         status = '网关故障';
         statusCls = 'text-red-700 bg-red-50';
-        detail = '最近5分钟无上报';
+        const staleMinutes = Math.max(1, Math.round(GATEWAY_STALE_MS / 60000));
+        detail = `最近${staleMinutes}分钟无上报`;
       } else if (sensorResult.isFault) {
         status = '传感器故障';
         statusCls = 'text-yellow-700 bg-yellow-50';
@@ -295,7 +310,7 @@ async function loadData() {
       return `<tr class="border-b">
         <td class="py-3 px-2">${formatTime(row.ts)}</td>
         <td class="py-3 px-2">${device}<span class="ml-1 text-xs text-gray-400">${row.sensor_id || ''}</span></td>
-        <td class="py-3 px-2">${ec === null ? '-' : `${ec.toFixed(1)} μS/cm`}</td>
+        <td class="py-3 px-2">${ec === null ? '-' : `${ec.toFixed(1)} ${FERTILITY_UNIT}`}</td>
         <td class="py-3 px-2"><span class="text-xs px-2 py-1 rounded-full ${statusCls}">${status}</span></td>
         <td class="py-3 px-2 text-xs text-gray-600">${detail}</td>
       </tr>`;
@@ -303,7 +318,9 @@ async function loadData() {
   }
 
   const imageBody = document.getElementById('imageBody');
-  const imageRows = [...imageUploads].sort((a, b) => Date.parse(b.captured_at || '') - Date.parse(a.captured_at || '')).slice(0, 10);
+  const imageRows = [...imageUploads]
+    .sort((a, b) => Date.parse(b.captured_at || '') - Date.parse(a.captured_at || ''))
+    .slice(0, IMAGE_TABLE_ROWS);
   if (!imageRows.length) {
     imageBody.innerHTML = '<tr><td colspan="5" class="py-4 text-center text-gray-500">暂无数据</td></tr>';
   } else {
@@ -335,7 +352,7 @@ window.onload = async () => {
     data: {
       labels: [],
       datasets: [{
-        label: 'EC(μS/cm)',
+        label: `${FERTILITY_FIELD.toUpperCase()}(${FERTILITY_UNIT})`,
         data: [],
         borderColor: '#16a34a',
         backgroundColor: 'rgba(22,163,74,0.1)',
@@ -377,5 +394,5 @@ window.onload = async () => {
 
   await loadSchema();
   await loadData();
-  setInterval(loadData, 15000);
+  setInterval(loadData, REFRESH_MS);
 };

--- a/cloud/dashboard/index.html
+++ b/cloud/dashboard/index.html
@@ -91,6 +91,7 @@
     </div>
   </main>
 
+  <script src="runtime-config.js"></script>
   <script src="app.js"></script>
 </body>
 </html>

--- a/cloud/dashboard/runtime-config.js
+++ b/cloud/dashboard/runtime-config.js
@@ -1,0 +1,46 @@
+/**
+ * Dashboard runtime config.
+ * Override via `window.AI_AG_DASHBOARD_CONFIG` before this script loads.
+ */
+(function initDashboardRuntimeConfig() {
+  const defaults = {
+    telemetry: {
+      gatewayStaleMs: 5 * 60 * 1000,
+      diseaseThreshold: 0.5,
+      refreshMs: 15000,
+      telemetryLimit: 300,
+      imageLimit: 50,
+      telemetryTableRows: 10,
+      imageTableRows: 10
+    },
+    sensors: {
+      fertilitySensorId: "soil_modbus_02",
+      fertilityField: "ec",
+      fertilityUnit: "μS/cm"
+    }
+  };
+
+  const deepMerge = (base, extra) => {
+    const out = { ...base };
+    Object.keys(extra || {}).forEach((key) => {
+      const bv = base?.[key];
+      const ev = extra[key];
+      if (
+        bv &&
+        typeof bv === "object" &&
+        !Array.isArray(bv) &&
+        ev &&
+        typeof ev === "object" &&
+        !Array.isArray(ev)
+      ) {
+        out[key] = deepMerge(bv, ev);
+      } else {
+        out[key] = ev;
+      }
+    });
+    return out;
+  };
+
+  const merged = deepMerge(defaults, window.AI_AG_DASHBOARD_CONFIG || {});
+  window.DASHBOARD_CONFIG = Object.freeze(merged);
+})();

--- a/cloud/src/constants.rs
+++ b/cloud/src/constants.rs
@@ -17,8 +17,8 @@ pub(crate) const DEFAULT_TELEMETRY_STORE_PATH: &str = "state/telemetry.jsonl";
 pub(crate) const DEFAULT_IMAGE_STORE_PATH: &str = "state/image_uploads";
 pub(crate) const DEFAULT_IMAGE_INDEX_PATH: &str = "state/image_index.jsonl";
 pub(crate) const DEFAULT_IMAGE_DB_ERROR_STORE_PATH: &str = "state/image_upload_errors.jsonl";
-pub(crate) const DEFAULT_AI_PREDICT_URL: &str = "http://127.0.0.1:8000/api/v1/predict";
-pub(crate) const DEFAULT_OPENCLAW_URL: &str = "http://127.0.0.1:3000";
+pub(crate) const DEFAULT_AI_PREDICT_URL: &str = "http://ai-engine:8000/api/v1/predict";
+pub(crate) const DEFAULT_OPENCLAW_URL: &str = "http://openclaw:3000";
 
 pub(crate) fn default_bind() -> String {
     std::env::var("CLOUD_BIND_ADDR").unwrap_or_else(|_| DEFAULT_BIND.to_string())
@@ -33,27 +33,29 @@ pub(crate) fn default_ack_unknown_sensor() -> String {
 }
 
 pub(crate) fn default_token_store_path() -> String {
-    DEFAULT_TOKEN_STORE_PATH.to_string()
+    std::env::var("TOKEN_STORE_PATH").unwrap_or_else(|_| DEFAULT_TOKEN_STORE_PATH.to_string())
 }
 
 pub(crate) fn default_registry_path() -> String {
-    DEFAULT_REGISTRY_PATH.to_string()
+    std::env::var("REGISTRY_PATH").unwrap_or_else(|_| DEFAULT_REGISTRY_PATH.to_string())
 }
 
 pub(crate) fn default_telemetry_store_path() -> String {
-    DEFAULT_TELEMETRY_STORE_PATH.to_string()
+    std::env::var("TELEMETRY_STORE_PATH")
+        .unwrap_or_else(|_| DEFAULT_TELEMETRY_STORE_PATH.to_string())
 }
 
 pub(crate) fn default_image_store_path() -> String {
-    DEFAULT_IMAGE_STORE_PATH.to_string()
+    std::env::var("IMAGE_STORE_PATH").unwrap_or_else(|_| DEFAULT_IMAGE_STORE_PATH.to_string())
 }
 
 pub(crate) fn default_image_index_path() -> String {
-    DEFAULT_IMAGE_INDEX_PATH.to_string()
+    std::env::var("IMAGE_INDEX_PATH").unwrap_or_else(|_| DEFAULT_IMAGE_INDEX_PATH.to_string())
 }
 
 pub(crate) fn default_image_db_error_store_path() -> String {
-    DEFAULT_IMAGE_DB_ERROR_STORE_PATH.to_string()
+    std::env::var("IMAGE_DB_ERROR_STORE_PATH")
+        .unwrap_or_else(|_| DEFAULT_IMAGE_DB_ERROR_STORE_PATH.to_string())
 }
 
 pub(crate) fn default_ai_predict_url() -> String {

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -14,9 +14,9 @@ services:
     build:
       context: .
       dockerfile: Dockerfile
-    container_name: smart-farm-ai-engine
+    container_name: ${AI_ENGINE_CONTAINER_NAME:-smart-farm-ai-engine}
     ports:
-      - "8000:8000"
+      - "${AI_ENGINE_PORT:-8000}:8000"
     volumes:
       # Mount model weights directory (read-only).
       # Place your best_model.pth inside models/rice_leaf_classifier/

--- a/service/.env.example
+++ b/service/.env.example
@@ -2,7 +2,10 @@
 # Copy this file to .env and adjust the values for your local or production environment.
 
 # CORS Configuration
-# CORS_ORIGINS=http://localhost:3000,http://127.0.0.1:9000
+# CORS_ORIGINS=http://localhost:8088,http://127.0.0.1:8088
+# CORS_ALLOW_CREDENTIALS=false
+# CORS_ALLOW_METHODS=GET,POST,OPTIONS
+# CORS_ALLOW_HEADERS=Authorization,Content-Type
 
 # Model Execution Overrides
 # MODEL_CHECKPOINT_PATH=models/rice_leaf_classifier/best_model.pth

--- a/service/main.py
+++ b/service/main.py
@@ -100,15 +100,30 @@ app = FastAPI(
     lifespan=lifespan,
 )
 
-# CORS — allow the Rust cloud backend to call this service
-cors_origins_env = os.environ.get("CORS_ORIGINS", "*")
+# CORS — allow trusted dashboard/backend origins (override in env)
+cors_origins_env = os.environ.get(
+    "CORS_ORIGINS",
+    "http://localhost:8088,http://127.0.0.1:8088",
+)
 allow_origins = [origin.strip() for origin in cors_origins_env.split(",") if origin.strip()]
+allow_credentials = os.environ.get("CORS_ALLOW_CREDENTIALS", "false").lower() == "true"
+allow_methods = [
+    method.strip()
+    for method in os.environ.get("CORS_ALLOW_METHODS", "GET,POST,OPTIONS").split(",")
+    if method.strip()
+]
+allow_headers = [
+    header.strip()
+    for header in os.environ.get("CORS_ALLOW_HEADERS", "Authorization,Content-Type").split(",")
+    if header.strip()
+]
 
 app.add_middleware(
     CORSMiddleware,
     allow_origins=allow_origins,
-    allow_methods=["*"],
-    allow_headers=["*"],
+    allow_credentials=allow_credentials,
+    allow_methods=allow_methods,
+    allow_headers=allow_headers,
 )
 
 app.include_router(predict_router)


### PR DESCRIPTION
## Summary
This PR finalizes the `dev`-side configuration decoupling work related to issue #49.

## What Changed
- `cloud/dashboard`
  - Added runtime config entry: `cloud/dashboard/runtime-config.js`
  - Injected runtime config in `index.html`
  - Replaced hardcoded thresholds/limits/refresh intervals/sensor mapping in `app.js` with runtime-config-driven values (with safe defaults)
- `docker-compose.yml`
  - `container_name` made configurable via `AI_ENGINE_CONTAINER_NAME`
  - host port mapping made configurable via `AI_ENGINE_PORT`
- `cloud/src/constants.rs`
  - State storage paths now support env override:
    - `TOKEN_STORE_PATH`, `REGISTRY_PATH`, `TELEMETRY_STORE_PATH`
    - `IMAGE_STORE_PATH`, `IMAGE_INDEX_PATH`, `IMAGE_DB_ERROR_STORE_PATH`
  - AI defaults adjusted to service-name style (`ai-engine` / `openclaw`) instead of fixed localhost assumptions
- `cloud/config/sensors.toml`
  - Sample endpoints switched from localhost-bound values to deployment-placeholder style (`db`, `ai-engine`, `openclaw`)
- `service/main.py`
  - CORS default tightened from wildcard to explicit origin list
  - Added env-driven controls for credentials/methods/headers
- `.env.example`
  - Expanded both `cloud/.env.example` and `service/.env.example` with the new override variables
- `README.md`
  - Added "Configuration-First Deployment Notes" and explicit acceptance rule: switch environments by config only

## Validation
- `node --check cloud/dashboard/runtime-config.js` ✅
- `node --check cloud/dashboard/app.js` ✅
- `cd cloud && cargo test` ✅
- `python -m py_compile service/main.py` ✅

## Scope Notes
- This PR targets `dev` only.
- Gateway-side decoupling and strict fallback cleanup were handled on `gateway-wsl` branch separately.

## Related
- Closes/advances: #49