### PR TITLE
Add global health endpoint, oil-palm mock APIs, resilient startup, and docs/tests updates

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,7 +16,7 @@ COPY requirements/ ./requirements/
 COPY requirements.txt .
 
 # Install base dependencies
-RUN pip install --no-cache-dir -r requirements/base.txt
+RUN pip install --no-cache-dir -r requirements.txt
 
 # Install crop-specific dependencies
 # Note: For Rice, we use the CPU-only index for torch/torchvision

--- a/ai_engine/README.md
+++ b/ai_engine/README.md
@@ -1,95 +1,53 @@
-# Service
+# AI Engine
 
-鐠囥儳娲拌ぐ鏇炲瘶閸?AI 閹恒劎鎮婂Ο鈥虫健閻ㄥ嫬鐣弫鏉戞磽鐏炲倹鐏﹂弸鍕杽閻滆埇鈧?
+`ai_engine` is the modular FastAPI inference service for AI-Agriculture.
 
-## 閻╊喖缍嶇紒鎾寸€?
+## Architecture
 
-*   `api/`: **(L1) 閹恒儱褰涚仦?* 閳?FastAPI 鐠侯垳鏁辨稉?HTTP 閻樿埖鈧胶鐖滄径鍕倞閵嗗倷绮庨崑姘崇熅閻㈠崬鍨庨崣鎴礉娑撱儳顩﹂崠鍛儓閹恒劎鎮婇柅鏄忕帆閵?
-    *   `v1/predict.py`: `POST /api/v1/predict` 閸?`GET /api/v1/health`閵?
-*   `adapters/`: **(L2) 闁倿鍘ら崳銊ョ湴** 閳?婢跺嫮鎮婃径鏍劥鏉堟挸鍙嗛敍鍫熸瀮娴犳儼鐭惧鍕┾偓浣哥摟閼哄倹绁﹂敍澶涚礉鏉烆剙瀵叉稉?core 鐏炲倸褰查惄瀛樺复娴ｈ法鏁ら惃鍕敶闁劎绮ㄩ弸?(PIL.Image)閵?
-*   `core/`: **(L3) 閺嶇绺鹃幒銊ф倞鐏?* 閳?缁?Python 缁犳纭堕柅鏄忕帆閵嗗倹澧嶉張澶嬆侀崹瀣埛閹佃儻鍤?`base_predictor.py` 娑擃厾娈?`BasePredictor`閵嗗倷寮楃粋浣割嚤閸?FastAPI閵?
-*   `schemas/`: **婵傛垹瀹崇仦?* 閳?Pydantic 閺佺増宓佺紒鎾寸€€规矮绠熼妴鍌涘閺堝膩閸ф妫块惃鍕殶閹诡喕绱堕柅鎺戞綆娴犮儲顒濇稉鍝勫櫙閵?
-*   `main.py`: FastAPI 鎼存梻鏁ら崗銉ュ經閵嗗倽绀嬬拹锝喣侀崹瀣暕閸旂姾娴囬妴涓哋RS 闁板秶鐤嗛崪灞藉弿鐏炩偓瀵倸鐖舵径鍕倞閵?
-*   `infer.py`: 閺堫剙婀撮崡鏇炴禈閹恒劎鎮?CLI 瀹搞儱鍙块敍鍫滅瑝娓氭繆绂?FastAPI閿涘鈧?
+- `common/`: shared adapters, schemas, and global endpoints (for example health).
+- `crops/rice/`: rice inference and training modules.
+- `crops/oil_palm/`: oil palm placeholder/mock modules for future expansion.
+- `main.py`: app composition entrypoint that includes routers.
+- `infer.py`: CLI inference utility (rice classifier).
 
-## 閸氼垰濮╅張宥呭
+## Run API Service
 
 ```bash
-# 瀵偓閸欐垶膩瀵骏绱欓懛顏勫З闁插秷娴囬敍?
 uvicorn ai_engine.main:app --reload --host 0.0.0.0 --port 8000
 ```
 
-### 閻滎垰顣ㄩ崣姗€鍣?
+## Environment Variables
 
-| 閸欐﹢鍣洪崥?| 鐠囧瓨妲?| 姒涙顓婚崐?|
-|--------|------|--------|
-| `MODEL_CHECKPOINT_PATH` | 濡€崇€烽弶鍐櫢閺傚洣娆㈢捄顖氱窞 | `models/rice/rice_leaf_classifier/best_model.pth` |
-| `MODEL_LABELS_FILE` | 閺嶅洨顒烽弬鍥︽鐠侯垰绶?| `models/rice/rice_leaf_classifier/labels.json` |
-| `MODEL_CONFIG_FILE` | 濡€崇€烽柊宥囩枂鐠侯垰绶?| `models/rice/rice_leaf_classifier/config.yaml` |
+| Variable | Description | Default |
+|---|---|---|
+| `CROP_PROFILE` | Active crop profile (`rice` or `oil_palm`) | `rice` |
+| `MODEL_CHECKPOINT_PATH` | Rice checkpoint path | `models/rice/rice_leaf_classifier/best_model.pth` |
+| `MODEL_LABELS_FILE` | Rice label map | `models/rice/rice_leaf_classifier/labels.json` |
+| `MODEL_CONFIG_FILE` | Rice model config | `models/rice/rice_leaf_classifier/config.yaml` |
+| `MODEL_ADVICE_FILE` | Rice advice map | `models/rice/rice_leaf_classifier/advice_map.yaml` |
 
-## API 缁旑垳鍋?
+## API Endpoints
 
-### POST /api/v1/predict
+### Global
 
-娑撳﹣绱舵稉鈧?JPEG/PNG 閸ュ墽澧栭敍宀冪箲閸ョ偟姊剧€瑰啿鍨庣猾鑽ょ波閺嬫嚎鈧?
+- `GET /api/v1/health` (profile-safe service health)
 
-```bash
-curl -X POST http://localhost:8000/api/v1/predict \
-  -F "file=@test_image.jpg"
-```
+### Rice
 
-**閹存劕濮涢崫宥呯安 (200)**:
-```json
-{
-  "status": "success",
-  "results": [
-    {
-      "predicted_class": "Leaf_Blast",
-      "confidence": 0.93,
-      "topk": [
-        {"label": "Leaf_Blast", "score": 0.93},
-        {"label": "Brown_Spot", "score": 0.05},
-        {"label": "HealthyLeaf", "score": 0.02}
-      ],
-      "model_version": "rice_cls_v0.1.0",
-      "metadata": {},
-      "geometry": null
-    }
-  ],
-  "metadata": {}
-}
-```
+- `POST /api/v1/predict` (legacy rice endpoint, backward compatibility)
+- `POST /api/v1/rice/predict` (explicit rice endpoint)
+- `GET /api/v1/rice/health` (rice model health)
 
-**闁挎瑨顕ら崫宥呯安 (422/500)**:
-```json
-{
-  "status": "error",
-  "message": "Cannot decode image from provided bytes"
-}
-```
+### Oil Palm (Mock)
 
-### GET /api/v1/health
+- `POST /api/v1/oil-palm/analyze-image`
+- `POST /api/v1/oil-palm/analyze-session`
+- `POST /api/v1/oil-palm/analyze-uav-mission`
 
-閸嬨儱鎮嶅Λ鈧弻銉礉閻劋绨?Docker/K8s 閹恒垽鎷￠妴?
-
-```json
-{
-  "status": "ok",
-  "service": "smart-farm-ai-engine",
-  "version": "0.1.0",
-  "model": {
-    "model_name": "RiceLeafClassifier",
-    "model_version": "rice_cls_v0.1.0",
-    "architecture": "resnet18",
-    "num_classes": "8"
-  }
-}
-```
-
-## 閺堫剙婀?CLI 閹恒劎鎮?
+## CLI Inference
 
 ```bash
-python service/infer.py \
+python -m ai_engine.infer \
   --image-path test.jpg \
   --checkpoint-path outputs/.../best_model.pth
 ```

--- a/ai_engine/common/health.py
+++ b/ai_engine/common/health.py
@@ -1,0 +1,17 @@
+"""Global, profile-safe health endpoint."""
+
+import os
+
+from fastapi import APIRouter
+
+router = APIRouter(tags=["common"])
+
+
+@router.get("/health", summary="Global service health check")
+async def health():
+    """Profile-safe health endpoint that does not require crop model loading."""
+    return {
+        "status": "ok",
+        "service": "smart-farm-ai-engine",
+        "crop_profile": os.environ.get("CROP_PROFILE", "rice").lower(),
+    }

--- a/ai_engine/crops/oil_palm/inference/api.py
+++ b/ai_engine/crops/oil_palm/inference/api.py
@@ -1,5 +1,4 @@
 from fastapi import APIRouter, File, UploadFile
-from ai_engine.common.schemas.prediction import ErrorResponse, PredictionResponse, PredictionResult, PredictionItem
 import logging
 
 logger = logging.getLogger(__name__)
@@ -8,36 +7,39 @@ router = APIRouter(tags=["oil_palm"])
 
 @router.post(
     "/oil-palm/analyze-image",
-    response_model=PredictionResponse,
     summary="Analyze oil palm image (Mock)",
 )
 async def analyze_image(file: UploadFile = File(...)):
     logger.info("Oil Palm: analyze-image request")
-    return PredictionResponse(results=[
-        PredictionResult(
-            predicted_class="RipeBunch",
-            confidence=0.95,
-            topk=[],
-            model_version="oil_palm_mock_v0.1",
-            metadata={"advice": "Harvest recommended"},
-            geometry={"type": "box", "coords": [10, 10, 100, 100]}
-        )
-    ])
+    return {
+        "crop": "oil_palm",
+        "status": "mock",
+        "message": "Oil palm pipeline placeholder is ready.",
+        "results": [],
+    }
 
 @router.post(
     "/oil-palm/analyze-session",
-    response_model=PredictionResponse,
     summary="Analyze oil palm session (Mock)",
 )
 async def analyze_session():
     logger.info("Oil Palm: analyze-session request")
-    return PredictionResponse(results=[])
+    return {
+        "crop": "oil_palm",
+        "status": "mock",
+        "message": "Oil palm pipeline placeholder is ready.",
+        "results": [],
+    }
 
 @router.post(
     "/oil-palm/analyze-uav-mission",
-    response_model=PredictionResponse,
     summary="Analyze oil palm UAV mission (Mock)",
 )
 async def analyze_uav_mission():
     logger.info("Oil Palm: analyze-uav-mission request")
-    return PredictionResponse(results=[])
+    return {
+        "crop": "oil_palm",
+        "status": "mock",
+        "message": "Oil palm pipeline placeholder is ready.",
+        "results": [],
+    }

--- a/ai_engine/crops/rice/inference/api.py
+++ b/ai_engine/crops/rice/inference/api.py
@@ -98,10 +98,10 @@ async def predict(file: UploadFile = File(...)):
 
 
 @router.get(
-    "/health",
-    summary="Service health check",
+    "/rice/health",
+    summary="Rice model health check",
 )
-async def health():
+async def rice_health():
     """Return service health status."""
     classifier = _get_classifier()
     model_info = classifier.get_model_info()

--- a/ai_engine/infer.py
+++ b/ai_engine/infer.py
@@ -3,17 +3,13 @@ import json
 import sys
 from pathlib import Path
 
-from PIL import Image
-
 try:
-    from ai_engine.crops.rice.inference.rice_leaf_classifier import RiceLeafClassifier
     from ai_engine.common.adapters.image_adapter import load_image_from_path
 except ModuleNotFoundError:
     # Support running `python ai_engine/infer.py` from the project root.
     project_root = Path(__file__).resolve().parent.parent
     if str(project_root) not in sys.path:
         sys.path.insert(0, str(project_root))
-    from ai_engine.crops.rice.inference.rice_leaf_classifier import RiceLeafClassifier
     from ai_engine.common.adapters.image_adapter import load_image_from_path
 
 
@@ -24,6 +20,8 @@ def predict_image_file(
     config_file: str = "models/rice/rice_leaf_classifier/config.yaml",
     top_k: int = 3
 ):
+    from ai_engine.crops.rice.inference.rice_leaf_classifier import RiceLeafClassifier
+
     image = load_image_from_path(image_path)
     classifier = RiceLeafClassifier(
         checkpoint_path=checkpoint_path,

--- a/ai_engine/main.py
+++ b/ai_engine/main.py
@@ -1,4 +1,4 @@
-"""Smart Farm AI Engine 閳?FastAPI application entry point.
+"""Smart Farm AI Engine FastAPI application entry point.
 
 Start the server with::
 
@@ -8,11 +8,11 @@ Configuration
 -------------
 The following environment variables are recognised:
 
-* ``MODEL_CHECKPOINT_PATH``  閳?path to the ``.pth`` checkpoint file.
+* ``MODEL_CHECKPOINT_PATH``  path to the ``.pth`` checkpoint file.
   Defaults to ``models/rice/rice_leaf_classifier/best_model.pth`` when unset.
-* ``MODEL_LABELS_FILE``      閳?path to ``labels.json``.
+* ``MODEL_LABELS_FILE``      path to ``labels.json``.
   Defaults to ``models/rice/rice_leaf_classifier/labels.json``.
-* ``MODEL_CONFIG_FILE``      閳?path to ``config.yaml``.
+* ``MODEL_CONFIG_FILE``      path to ``config.yaml``.
   Defaults to ``models/rice/rice_leaf_classifier/config.yaml``.
 """
 
@@ -25,6 +25,7 @@ from fastapi.middleware.cors import CORSMiddleware
 from fastapi.responses import JSONResponse
 
 from ai_engine.common.adapters.image_adapter import ImageLoadError
+from ai_engine.common.health import router as common_router
 from ai_engine.crops.rice.inference.api import router as rice_router, set_classifier
 from ai_engine.crops.oil_palm.inference.api import router as oil_palm_router
 
@@ -63,7 +64,7 @@ MODEL_ADVICE_FILE = os.environ.get(
 
 
 # ------------------------------------------------------------------
-# Lifespan 閳?model preloading at startup
+# Lifespan: model preloading at startup
 # ------------------------------------------------------------------
 
 @asynccontextmanager
@@ -72,16 +73,20 @@ async def lifespan(app: FastAPI):
     logger.info("=== Smart Farm AI Engine starting [%s] ===", CROP_PROFILE)
     
     if CROP_PROFILE == "rice":
-        from ai_engine.crops.rice.inference.rice_leaf_classifier import RiceLeafClassifier
-        logger.info("Loading Rice Model Assets...")
-        classifier = RiceLeafClassifier(
-            checkpoint_path=MODEL_CHECKPOINT_PATH,
-            labels_file=MODEL_LABELS_FILE,
-            config_file=MODEL_CONFIG_FILE,
-            advice_file=MODEL_ADVICE_FILE,
-        )
-        set_classifier(classifier)
-        logger.info("Rice model loaded successfully.")
+        try:
+            from ai_engine.crops.rice.inference.rice_leaf_classifier import RiceLeafClassifier
+
+            logger.info("Loading Rice Model Assets...")
+            classifier = RiceLeafClassifier(
+                checkpoint_path=MODEL_CHECKPOINT_PATH,
+                labels_file=MODEL_LABELS_FILE,
+                config_file=MODEL_CONFIG_FILE,
+                advice_file=MODEL_ADVICE_FILE,
+            )
+            set_classifier(classifier)
+            logger.info("Rice model loaded successfully.")
+        except Exception as exc:
+            logger.warning("Rice model was not loaded at startup: %s", exc)
     elif CROP_PROFILE == "oil_palm":
         logger.info("Oil Palm mode: Using mock/future YOLOv8 predictor.")
     
@@ -100,7 +105,7 @@ app = FastAPI(
     lifespan=lifespan,
 )
 
-# CORS 閳?allow trusted dashboard/backend origins (override in env)
+# CORS: allow trusted dashboard/backend origins (override in env)
 cors_origins_env = os.environ.get(
     "CORS_ORIGINS",
     "http://localhost:8088,http://127.0.0.1:8088",
@@ -126,17 +131,18 @@ app.add_middleware(
     allow_headers=allow_headers,
 )
 
+app.include_router(common_router, prefix="/api/v1")
 app.include_router(rice_router, prefix="/api/v1")
 app.include_router(oil_palm_router, prefix="/api/v1")
 
 
 # ------------------------------------------------------------------
-# Global exception handlers 閳?graceful degradation
+# Global exception handlers: graceful degradation
 # ------------------------------------------------------------------
 
 @app.exception_handler(ImageLoadError)
 async def image_load_error_handler(request: Request, exc: ImageLoadError):
-    """Image could not be decoded 閳?client's fault (422)."""
+    """Image could not be decoded: client fault (422)."""
     logger.warning("ImageLoadError: %s", exc)
     return JSONResponse(
         status_code=422,
@@ -146,7 +152,7 @@ async def image_load_error_handler(request: Request, exc: ImageLoadError):
 
 @app.exception_handler(Exception)
 async def global_exception_handler(request: Request, exc: Exception):
-    """Catch-all for unexpected errors 閳?never expose a raw 500."""
+    """Catch-all for unexpected errors: never expose a raw 500."""
     logger.error("Unhandled exception on %s %s: %s", request.method, request.url.path, exc, exc_info=True)
     return JSONResponse(
         status_code=500,

--- a/doc/ai/README.md
+++ b/doc/ai/README.md
@@ -1,52 +1,50 @@
-# AI 妯″潡璇存槑
+# AI Module Notes
 
-鏈洰褰曠敤浜庣淮鎶?AI 妯″潡鐩稿叧鏂囨。锛屽寘鎷細
-- API 璇存槑
-- 妯″瀷鏂规
-- 鏁版嵁璇存槑
-- 閮ㄧ讲璇存槑
+This folder documents the AI module, including:
+
+- API notes
+- model/training notes
+- data notes
+- deployment notes
 
 ## Current Stage
-- Task: Image Classification (NOT object detection)
-- Dataset: Rice Leaf Spot Disease Annotated Dataset (YOLO format)
-- Model: ResNet18
+
+- Task: image classification (not object detection)
+- Dataset: Rice Leaf Spot Disease Annotated Dataset (YOLO format source, converted for classification)
+- Baseline model: ResNet18
 - Classes: 8
-- Input Size: 224
+- Input size: 224
+
 ## Workflow
-### 1. Prepare Dataset (Detection 鈫?Classification)
+
+### 1) Prepare dataset (detection -> classification)
+
 ```bash
 python scripts/prepare_rice_cls_dataset.py --dataset-root "local_data/rice_leaf_spot_disease_annotated_dataset"
 ```
 
-### 2. Train Model
+### 2) Train
 
-  python scripts/train_rice_leaf_classifier.py
-
-### 3. Run Inference
 ```bash
-python service/infer.py \
-    --image-path "your_image.jpg" \
-    --checkpoint-path "outputs/rice_leaf_classifier/checkpoints/best_model.pth"
+python scripts/train_rice_leaf_classifier.py
 ```
 
-Important Notes
----------------
+### 3) Run inference
 
-* The dataset is NOT included in this repository.
-
-* Place dataset under:
+```bash
+python -m ai_engine.infer \
+  --image-path "your_image.jpg" \
+  --checkpoint-path "outputs/rice_leaf_classifier/checkpoints/best_model.pth"
 ```
-  local_data/
-```
-* This project currently uses classification baseline.
 
-* Bounding boxes are ignored in this stage.
+## Notes
 
-Future Work
------------
+- Dataset files are not included in this repository.
+- Place local datasets under `local_data/`.
+- Current baseline ignores bounding boxes for classification stage.
 
-* Object detection (YOLO / Faster R-CNN)
+## Future
 
-* Multi-label classification
-
-* Multi-crop support
+- Object detection (YOLO / Faster R-CNN)
+- Multi-label classification
+- Multi-crop support

--- a/frontend/rice/chat.js
+++ b/frontend/rice/chat.js
@@ -149,7 +149,7 @@ window.CHAT = (() => {
                 body: JSON.stringify({
                     message: msg,
                     context: {
-                        source: 'frontend_v2_premium',
+                        source: 'frontend_rice',
                         ts: new Date().toISOString(),
                     },
                 }),

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -88,7 +88,7 @@ async def client():
     """Create an HTTPX ASGI client with the model injected."""
     mock_classifier = _make_mock_classifier()
 
-    from ai_engine.api.v1.predict import set_classifier
+    from ai_engine.crops.rice.inference.api import set_classifier
     from ai_engine.main import app
 
     set_classifier(mock_classifier)
@@ -115,7 +115,7 @@ class TestHealthEndpoint:
         data = (await client.get("/api/v1/health")).json()
         assert data["status"] == "ok"
         assert data["service"] == "smart-farm-ai-engine"
-        assert "model" in data
+        assert "crop_profile" in data
 
 
 # ------------------------------------------------------------------
@@ -158,6 +158,42 @@ class TestPredictEndpoint:
         for item in topk:
             assert "label" in item
             assert "score" in item
+
+    @pytest.mark.anyio
+    async def test_rice_predict_endpoint_works(self, client):
+        image_bytes = _create_test_image_bytes()
+        response = await client.post(
+            "/api/v1/rice/predict",
+            files={"file": ("test.jpg", image_bytes, "image/jpeg")},
+        )
+        assert response.status_code == 200
+        assert response.json()["status"] == "success"
+
+
+class TestOilPalmMockEndpoints:
+    @pytest.mark.anyio
+    async def test_oil_palm_analyze_image_mock(self, client):
+        image_bytes = _create_test_image_bytes()
+        response = await client.post(
+            "/api/v1/oil-palm/analyze-image",
+            files={"file": ("test.jpg", image_bytes, "image/jpeg")},
+        )
+        assert response.status_code == 200
+        data = response.json()
+        assert data["crop"] == "oil_palm"
+        assert data["status"] == "mock"
+
+    @pytest.mark.anyio
+    async def test_oil_palm_analyze_session_mock(self, client):
+        response = await client.post("/api/v1/oil-palm/analyze-session")
+        assert response.status_code == 200
+        assert response.json()["status"] == "mock"
+
+    @pytest.mark.anyio
+    async def test_oil_palm_analyze_uav_mission_mock(self, client):
+        response = await client.post("/api/v1/oil-palm/analyze-uav-mission")
+        assert response.status_code == 200
+        assert response.json()["status"] == "mock"
 
 
 # ------------------------------------------------------------------


### PR DESCRIPTION
### Motivation
- Provide a profile-safe global health endpoint and explicit per-crop endpoints to support multi-profile operation and backward compatibility.
- Add placeholder/mock oil-palm APIs to surface the future pipeline without requiring model assets.
- Make the app resilient to missing model artifacts at startup so the service can boot in environments without rice model files.
- Refresh docs, CLI invocation, and frontend source tagging to match the multi-profile layout.

### Description
- Add `ai_engine/common/health.py` and register it at `/api/v1` to expose a global, profile-safe health check (`crop_profile` is returned).
- Move rice health endpoint to `/api/v1/rice/health` and rename the handler to `rice_health`, while keeping the legacy `POST /api/v1/predict` and adding `/api/v1/rice/predict` for explicit routing.
- Implement oil-palm mock endpoints in `ai_engine/crops/oil_palm/inference/api.py` returning simple JSON placeholders and remove the strict Pydantic response models.
- Make model preloading in `ai_engine/main.py` tolerant to failures by wrapping rice model import/initialization in a `try/except` and logging a warning instead of failing startup, and include the new common router.
- Update `ai_engine/infer.py` to support running as a module and perform the rice classifier import at runtime inside `predict_image_file` so the CLI works when running `python -m ai_engine.infer`.
- Update `Dockerfile` to install Python dependencies from `requirements.txt` (instead of `requirements/base.txt`), update README/Docs (`ai_engine/README.md`, `doc/ai/README.md`) to reflect multi-profile usage and the `python -m ai_engine.infer` invocation, and tweak frontend source tag in `frontend/rice/chat.js`.
- Update tests in `tests/test_api.py` to assert the new health payload (`crop_profile`) and to exercise rice and oil-palm endpoints (added tests for `/api/v1/rice/predict` and oil-palm mock endpoints).

### Testing
- Ran the API integration tests with `pytest tests/test_api.py` (async HTTPX ASGI tests that are gated by PyTorch availability); all tests passed.
- The test suite includes checks for global health, rice predict happy/error paths, rice-specific predict, and oil-palm mock endpoints, and all assertions succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f00db3fbfc83219ed38b52b21f5b1b)