### PR TITLE
perf(chat): warm adapter workers + staircase stress CLI (#60)

### DIFF
--- a/cloud/README.md
+++ b/cloud/README.md
@@ -160,6 +160,20 @@ chmod +x scripts/install_openclaw_chat_adapter.sh
 It starts `openclaw-chat-adapter` on `127.0.0.1:3000` and bridges chat requests to:
 `openclaw agent --local --agent main --message ... --json`.
 
+Adapter performance knobs (for cold-start mitigation):
+
+- `CHAT_ADAPTER_WORKERS` (default `2`): bounded concurrent CLI workers
+- `CHAT_ADAPTER_TIMEOUT_SEC` (default `180`)
+- `CHAT_ADAPTER_CWD` (default `/opt/ai-agriculture/cloud`)
+- startup warmup is enabled by default (can disable with `--no-warmup`)
+
+Example:
+
+```bash
+CHAT_ADAPTER_WORKERS=4 CHAT_ADAPTER_TIMEOUT_SEC=90 \
+python3 scripts/openclaw_chat_adapter.py --host 127.0.0.1 --port 3000
+```
+
 ## Auth API (issue #64 baseline)
 
 Auth is session-token based for management/business APIs:
@@ -294,6 +308,28 @@ python3 scripts/image_stress_cli.py set-rate --hz 1 --control-file /tmp/image_st
 python3 scripts/image_stress_cli.py set-rate --interval-sec 0.2 --control-file /tmp/image_stress_control.json
 python3 scripts/image_stress_cli.py show-rate --control-file /tmp/image_stress_control.json
 python3 scripts/image_stress_cli.py stop --control-file /tmp/image_stress_control.json
+```
+
+## Chat stress CLI (hot frequency + staircase)
+
+Run continuously and every 5 seconds reduce interval by 0.1 seconds (never auto-stop):
+
+```bash
+python3 scripts/chat_stress_cli.py run \
+  --url http://127.0.0.1:9001/api/v1/chat \
+  --interval-sec 1.0 \
+  --stair-enable \
+  --stair-every-sec 5 \
+  --stair-delta-sec 0.1 \
+  --control-file /tmp/chat_stress_control.json
+```
+
+Hot-control commands:
+
+```bash
+python3 scripts/chat_stress_cli.py set-rate --interval-sec 0.5 --control-file /tmp/chat_stress_control.json
+python3 scripts/chat_stress_cli.py show --control-file /tmp/chat_stress_control.json
+python3 scripts/chat_stress_cli.py stop --control-file /tmp/chat_stress_control.json
 ```
 
 Notes:

--- a/cloud/scripts/chat_stress_cli.py
+++ b/cloud/scripts/chat_stress_cli.py
@@ -1,0 +1,180 @@
+﻿#!/usr/bin/env python3
+"""Chat stress CLI with hot frequency change.
+
+Features:
+- Continuous POST /api/v1/chat pressure
+- Shared control file for live rate change
+- Stair mode: every N seconds decrease interval by delta, never stop
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import threading
+import time
+import urllib.error
+import urllib.request
+from pathlib import Path
+
+
+def load_control(path: Path, default_interval: float) -> dict:
+    if path.exists():
+        try:
+            return json.loads(path.read_text(encoding="utf-8"))
+        except Exception:
+            pass
+    state = {"interval_sec": default_interval, "stop": False, "message": "health check"}
+    path.write_text(json.dumps(state, ensure_ascii=False, indent=2), encoding="utf-8")
+    return state
+
+
+def save_control(path: Path, state: dict) -> None:
+    path.write_text(json.dumps(state, ensure_ascii=False, indent=2), encoding="utf-8")
+
+
+def post_chat(url: str, message: str, timeout: float) -> tuple[bool, float, str]:
+    body = json.dumps({"message": message, "context": {"source": "chat_stress_cli"}}).encode("utf-8")
+    req = urllib.request.Request(url, data=body, method="POST")
+    req.add_header("Content-Type", "application/json")
+    start = time.perf_counter()
+    try:
+        with urllib.request.urlopen(req, timeout=timeout) as resp:
+            payload = resp.read().decode("utf-8", errors="replace")
+            elapsed_ms = (time.perf_counter() - start) * 1000.0
+            return True, elapsed_ms, payload[:160]
+    except urllib.error.HTTPError as exc:
+        elapsed_ms = (time.perf_counter() - start) * 1000.0
+        return False, elapsed_ms, f"HTTP {exc.code}"
+    except Exception as exc:
+        elapsed_ms = (time.perf_counter() - start) * 1000.0
+        return False, elapsed_ms, str(exc)
+
+
+def run(args: argparse.Namespace) -> None:
+    control_file = Path(args.control_file)
+    state = load_control(control_file, args.interval_sec)
+
+    if args.stair_enable:
+        def stair_loop() -> None:
+            while True:
+                time.sleep(args.stair_every_sec)
+                s = load_control(control_file, args.interval_sec)
+                if s.get("stop"):
+                    return
+                cur = float(s.get("interval_sec", args.interval_sec))
+                nxt = max(args.min_interval_sec, cur - args.stair_delta_sec)
+                s["interval_sec"] = nxt
+                save_control(control_file, s)
+                print(f"[stair] interval_sec {cur:.3f} -> {nxt:.3f}")
+
+        threading.Thread(target=stair_loop, daemon=True).start()
+
+    n = 0
+    ok = 0
+    fail = 0
+    while True:
+        s = load_control(control_file, args.interval_sec)
+        if s.get("stop"):
+            print("[run] stop=true, exit")
+            return
+
+        interval = max(args.min_interval_sec, float(s.get("interval_sec", args.interval_sec)))
+        message = str(s.get("message", args.message))
+
+        succ, ms, detail = post_chat(args.url, message, args.timeout_sec)
+        n += 1
+        if succ:
+            ok += 1
+            print(f"[{n}] ok {ms:.1f}ms interval={interval:.3f}s {detail}")
+        else:
+            fail += 1
+            print(f"[{n}] fail {ms:.1f}ms interval={interval:.3f}s {detail}")
+
+        if args.report_every > 0 and n % args.report_every == 0:
+            rate = (ok / n) * 100.0
+            print(f"[report] total={n} ok={ok} fail={fail} success_rate={rate:.1f}%")
+
+        time.sleep(interval)
+
+
+def set_rate(args: argparse.Namespace) -> None:
+    p = Path(args.control_file)
+    s = load_control(p, args.interval_sec if args.interval_sec else 1.0)
+    if args.interval_sec is not None:
+        s["interval_sec"] = max(0.05, args.interval_sec)
+    if args.message is not None:
+        s["message"] = args.message
+    save_control(p, s)
+    print(json.dumps(s, ensure_ascii=False))
+
+
+def stop(args: argparse.Namespace) -> None:
+    p = Path(args.control_file)
+    s = load_control(p, 1.0)
+    s["stop"] = True
+    save_control(p, s)
+    print("stopped")
+
+
+def show(args: argparse.Namespace) -> None:
+    p = Path(args.control_file)
+    s = load_control(p, 1.0)
+    print(json.dumps(s, ensure_ascii=False, indent=2))
+
+
+def reset(args: argparse.Namespace) -> None:
+    p = Path(args.control_file)
+    s = {"interval_sec": args.interval_sec, "stop": False, "message": args.message}
+    save_control(p, s)
+    print(json.dumps(s, ensure_ascii=False, indent=2))
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description="Chat stress CLI")
+    sub = parser.add_subparsers(dest="cmd", required=True)
+
+    p_run = sub.add_parser("run", help="run stress loop")
+    p_run.add_argument("--url", default="http://127.0.0.1:9001/api/v1/chat")
+    p_run.add_argument("--message", default="health check")
+    p_run.add_argument("--timeout-sec", type=float, default=60.0)
+    p_run.add_argument("--interval-sec", type=float, default=1.0)
+    p_run.add_argument("--min-interval-sec", type=float, default=0.05)
+    p_run.add_argument("--control-file", default="/tmp/chat_stress_control.json")
+    p_run.add_argument("--report-every", type=int, default=20)
+    p_run.add_argument("--stair-enable", action="store_true")
+    p_run.add_argument("--stair-every-sec", type=float, default=5.0)
+    p_run.add_argument("--stair-delta-sec", type=float, default=0.1)
+    p_run.set_defaults(func=run)
+
+    p_set = sub.add_parser("set-rate", help="hot change interval/message")
+    p_set.add_argument("--control-file", default="/tmp/chat_stress_control.json")
+    p_set.add_argument("--interval-sec", type=float)
+    p_set.add_argument("--message")
+    p_set.set_defaults(func=set_rate)
+
+    p_stop = sub.add_parser("stop", help="stop running loop")
+    p_stop.add_argument("--control-file", default="/tmp/chat_stress_control.json")
+    p_stop.set_defaults(func=stop)
+
+    p_show = sub.add_parser("show", help="show current control state")
+    p_show.add_argument("--control-file", default="/tmp/chat_stress_control.json")
+    p_show.set_defaults(func=show)
+
+    p_reset = sub.add_parser("reset", help="reset control state")
+    p_reset.add_argument("--control-file", default="/tmp/chat_stress_control.json")
+    p_reset.add_argument("--interval-sec", type=float, default=1.0)
+    p_reset.add_argument("--message", default="health check")
+    p_reset.set_defaults(func=reset)
+
+    return parser
+
+
+def main() -> None:
+    parser = build_parser()
+    args = parser.parse_args()
+    args.func(args)
+
+
+if __name__ == "__main__":
+    main()

--- a/cloud/scripts/openclaw_chat_adapter.py
+++ b/cloud/scripts/openclaw_chat_adapter.py
@@ -1,145 +1,234 @@
-#!/usr/bin/env python3
-"""OpenClaw HTTP chat adapter.
-
-Exposes POST /api/v1/chat with JSON {message, context?}
-and proxies to OpenClaw CLI local agent.
-"""
-
-from __future__ import annotations
-
-import argparse
-import json
-import os
-import subprocess
-from http import HTTPStatus
-from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
-
-SYSTEM_HINT = (
-    "You are operating on the cloud host as root-level operator. "
-    "Prefer AI-ag whitelist commands for status checks. "
-    "Do not confuse gateway registration with sensor telemetry registration: "
-    "gateway/device registration is at device level, sensor_id is telemetry payload dimension."
-)
-
-
-class ChatHandler(BaseHTTPRequestHandler):
-    server_version = "openclaw-chat-adapter/0.1"
-
-    def _write_json(self, status: int, payload: dict) -> None:
-        body = json.dumps(payload, ensure_ascii=False).encode("utf-8")
-        self.send_response(status)
-        self.send_header("Content-Type", "application/json; charset=utf-8")
-        self.send_header("Content-Length", str(len(body)))
-        self.end_headers()
-        self.wfile.write(body)
-
-    def log_message(self, format: str, *args):  # noqa: A003
-        # Keep stdout clean; systemd journal still has status via access logs if needed.
-        return
-
-    def do_POST(self):  # noqa: N802
-        if self.path != "/api/v1/chat":
-            self._write_json(HTTPStatus.NOT_FOUND, {"status": "error", "message": "not found"})
-            return
-
-        try:
-            content_length = int(self.headers.get("Content-Length", "0"))
-        except ValueError:
-            content_length = 0
-        body = self.rfile.read(content_length)
-
-        try:
-            data = json.loads(body.decode("utf-8") if body else "{}")
-        except Exception as exc:  # noqa: BLE001
-            self._write_json(HTTPStatus.BAD_REQUEST, {"status": "error", "message": f"invalid json: {exc}"})
-            return
-
-        message = str(data.get("message", "")).strip()
-        context = data.get("context", {})
-        if not message:
-            self._write_json(HTTPStatus.BAD_REQUEST, {"status": "error", "message": "message must not be empty"})
-            return
-
-        prompt = f"[system]\\n{SYSTEM_HINT}\\n\\n[user]\\n{message}"
-        if context:
-            try:
-                prompt += "\n\n[context]\n" + json.dumps(context, ensure_ascii=False)
-            except Exception:  # noqa: BLE001
-                pass
-
-        cmd = [
-            "openclaw",
-            "agent",
-            "--local",
-            "--agent",
-            "main",
-            "--message",
-            prompt,
-            "--json",
-        ]
-
-        try:
-            env = dict(os.environ)
-            env.setdefault("HOME", "/root")
-            proc = subprocess.run(
-                cmd,
-                capture_output=True,
-                text=True,
-                timeout=180,
-                check=False,
-                cwd="/opt/ai-agriculture/cloud",
-                env=env,
-            )
-        except subprocess.TimeoutExpired:
-            self._write_json(HTTPStatus.GATEWAY_TIMEOUT, {"status": "error", "message": "openclaw request timeout"})
-            return
-        except Exception as exc:  # noqa: BLE001
-            self._write_json(HTTPStatus.SERVICE_UNAVAILABLE, {"status": "error", "message": f"openclaw exec failed: {exc}"})
-            return
-
-        if proc.returncode != 0:
-            err = (proc.stderr or proc.stdout or "openclaw failed").strip()
-            self._write_json(HTTPStatus.SERVICE_UNAVAILABLE, {"status": "error", "message": err[:1000]})
-            return
-
-        text = (proc.stdout or "").strip()
-        if "{" not in text:
-            text = (proc.stderr or "").strip()
-        start = text.find("{")
-        end = text.rfind("}")
-        if start < 0 or end < start:
-            self._write_json(HTTPStatus.SERVICE_UNAVAILABLE, {"status": "error", "message": "invalid openclaw response"})
-            return
-
-        try:
-            result = json.loads(text[start : end + 1])
-            payloads = result.get("payloads") or []
-            reply = None
-            for item in reversed(payloads):
-                if isinstance(item, dict) and isinstance(item.get("text"), str) and item["text"].strip():
-                    reply = item["text"].strip()
-                    break
-        except Exception as exc:  # noqa: BLE001
-            self._write_json(HTTPStatus.SERVICE_UNAVAILABLE, {"status": "error", "message": f"parse error: {exc}"})
-            return
-
-        if not reply:
-            self._write_json(HTTPStatus.SERVICE_UNAVAILABLE, {"status": "error", "message": "openclaw response missing reply"})
-            return
-
-        self._write_json(HTTPStatus.OK, {"reply": reply})
-
-
-def main() -> None:
-    parser = argparse.ArgumentParser(description="OpenClaw /api/v1/chat adapter")
-    parser.add_argument("--host", default="127.0.0.1")
-    parser.add_argument("--port", type=int, default=3000)
-    args = parser.parse_args()
-
-    server = ThreadingHTTPServer((args.host, args.port), ChatHandler)
-    print(f"[openclaw-chat-adapter] listening on http://{args.host}:{args.port}")
-    server.serve_forever()
-
-
-if __name__ == "__main__":
-    main()
+﻿#!/usr/bin/env python3
+"""OpenClaw HTTP chat adapter.
+
+Exposes POST /api/v1/chat with JSON {message, context?}
+and proxies to OpenClaw CLI local agent.
+
+Optimization goals:
+- keep adapter process hot (no Python cold start per request)
+- bounded worker pool for CLI calls
+- optional warmup on startup to reduce first-request latency
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import queue
+import subprocess
+import threading
+import time
+from http import HTTPStatus
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+from typing import Any
+
+SYSTEM_HINT = (
+    "You are operating on the cloud host as root-level operator. "
+    "Prefer AI-ag whitelist commands for status checks. "
+    "Do not confuse gateway registration with sensor telemetry registration: "
+    "gateway/device registration is at device level, sensor_id is telemetry payload dimension."
+)
+
+
+class OpenClawAdapter:
+    def __init__(self, timeout_sec: float, workers: int, cwd: str) -> None:
+        self.timeout_sec = timeout_sec
+        self.cwd = cwd
+        self.workers = max(1, workers)
+        self.env = dict(os.environ)
+        self.env.setdefault("HOME", "/root")
+        self.jobs: "queue.Queue[tuple[list[str], queue.Queue[tuple[bool, Any]]]]" = queue.Queue()
+        self._threads: list[threading.Thread] = []
+
+        for idx in range(self.workers):
+            t = threading.Thread(
+                target=self._worker_loop,
+                name=f"openclaw-worker-{idx}",
+                daemon=True,
+            )
+            t.start()
+            self._threads.append(t)
+
+    def _run_once(self, cmd: list[str]) -> str:
+        try:
+            proc = subprocess.run(
+                cmd,
+                capture_output=True,
+                text=True,
+                timeout=self.timeout_sec,
+                check=False,
+                cwd=self.cwd,
+                env=self.env,
+            )
+        except subprocess.TimeoutExpired as exc:
+            raise TimeoutError("openclaw request timeout") from exc
+        except Exception as exc:  # noqa: BLE001
+            raise RuntimeError(f"openclaw exec failed: {exc}") from exc
+
+        if proc.returncode != 0:
+            err = (proc.stderr or proc.stdout or "openclaw failed").strip()
+            raise RuntimeError(err[:1000])
+
+        text = (proc.stdout or "").strip()
+        if "{" not in text:
+            text = (proc.stderr or "").strip()
+        start = text.find("{")
+        end = text.rfind("}")
+        if start < 0 or end < start:
+            raise RuntimeError("invalid openclaw response")
+
+        try:
+            result = json.loads(text[start : end + 1])
+            payloads = result.get("payloads") or []
+            reply = None
+            for item in reversed(payloads):
+                if isinstance(item, dict) and isinstance(item.get("text"), str) and item["text"].strip():
+                    reply = item["text"].strip()
+                    break
+        except Exception as exc:  # noqa: BLE001
+            raise RuntimeError(f"parse error: {exc}") from exc
+
+        if not reply:
+            raise RuntimeError("openclaw response missing reply")
+        return reply
+
+    def _worker_loop(self) -> None:
+        while True:
+            cmd, result_q = self.jobs.get()
+            try:
+                result_q.put((True, self._run_once(cmd)))
+            except Exception as exc:  # noqa: BLE001
+                result_q.put((False, exc))
+            finally:
+                self.jobs.task_done()
+
+    def call_openclaw(self, cmd: list[str]) -> str:
+        result_q: "queue.Queue[tuple[bool, Any]]" = queue.Queue(maxsize=1)
+        self.jobs.put((cmd, result_q))
+        try:
+            ok, payload = result_q.get(timeout=self.timeout_sec + 2.0)
+        except queue.Empty as exc:
+            raise TimeoutError("openclaw queue timeout") from exc
+
+        if ok:
+            return payload
+        if isinstance(payload, TimeoutError):
+            raise payload
+        if isinstance(payload, RuntimeError):
+            raise payload
+        raise RuntimeError(str(payload))
+
+    def warmup(self) -> None:
+        warmup_cmd = [
+            "openclaw",
+            "agent",
+            "--local",
+            "--agent",
+            "main",
+            "--message",
+            "[system]\\nWarmup ping, reply with short ok.",
+            "--json",
+        ]
+        start = time.time()
+        try:
+            self.call_openclaw(warmup_cmd)
+            print(f"[openclaw-chat-adapter] warmup ok in {(time.time() - start):.2f}s")
+        except Exception as exc:  # noqa: BLE001
+            print(f"[openclaw-chat-adapter] warmup skipped: {exc}")
+
+
+class ChatHandler(BaseHTTPRequestHandler):
+    server_version = "openclaw-chat-adapter/0.2"
+
+    def _write_json(self, status: int, payload: dict) -> None:
+        body = json.dumps(payload, ensure_ascii=False).encode("utf-8")
+        self.send_response(status)
+        self.send_header("Content-Type", "application/json; charset=utf-8")
+        self.send_header("Content-Length", str(len(body)))
+        self.end_headers()
+        self.wfile.write(body)
+
+    def log_message(self, format: str, *args):  # noqa: A003
+        return
+
+    def do_POST(self):  # noqa: N802
+        if self.path != "/api/v1/chat":
+            self._write_json(HTTPStatus.NOT_FOUND, {"status": "error", "message": "not found"})
+            return
+
+        try:
+            content_length = int(self.headers.get("Content-Length", "0"))
+        except ValueError:
+            content_length = 0
+        body = self.rfile.read(content_length)
+
+        try:
+            data = json.loads(body.decode("utf-8") if body else "{}")
+        except Exception as exc:  # noqa: BLE001
+            self._write_json(HTTPStatus.BAD_REQUEST, {"status": "error", "message": f"invalid json: {exc}"})
+            return
+
+        message = str(data.get("message", "")).strip()
+        context = data.get("context", {})
+        if not message:
+            self._write_json(HTTPStatus.BAD_REQUEST, {"status": "error", "message": "message must not be empty"})
+            return
+
+        prompt = f"[system]\\n{SYSTEM_HINT}\\n\\n[user]\\n{message}"
+        if context:
+            try:
+                prompt += "\n\n[context]\n" + json.dumps(context, ensure_ascii=False)
+            except Exception:  # noqa: BLE001
+                pass
+
+        cmd = [
+            "openclaw",
+            "agent",
+            "--local",
+            "--agent",
+            "main",
+            "--message",
+            prompt,
+            "--json",
+        ]
+
+        try:
+            reply = self.server.adapter.call_openclaw(cmd)  # type: ignore[attr-defined]
+        except TimeoutError:
+            self._write_json(HTTPStatus.GATEWAY_TIMEOUT, {"status": "error", "message": "openclaw request timeout"})
+            return
+        except RuntimeError as exc:
+            self._write_json(HTTPStatus.SERVICE_UNAVAILABLE, {"status": "error", "message": str(exc)})
+            return
+
+        self._write_json(HTTPStatus.OK, {"reply": reply})
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="OpenClaw /api/v1/chat adapter")
+    parser.add_argument("--host", default=os.getenv("CHAT_ADAPTER_HOST", "127.0.0.1"))
+    parser.add_argument("--port", type=int, default=int(os.getenv("CHAT_ADAPTER_PORT", "3000")))
+    parser.add_argument("--timeout-sec", type=float, default=float(os.getenv("CHAT_ADAPTER_TIMEOUT_SEC", "180")))
+    parser.add_argument("--workers", type=int, default=int(os.getenv("CHAT_ADAPTER_WORKERS", "2")))
+    parser.add_argument("--cwd", default=os.getenv("CHAT_ADAPTER_CWD", "/opt/ai-agriculture/cloud"))
+    parser.add_argument("--no-warmup", action="store_true", help="Disable startup warmup request.")
+    args = parser.parse_args()
+
+    server = ThreadingHTTPServer((args.host, args.port), ChatHandler)
+    server.adapter = OpenClawAdapter(
+        timeout_sec=max(5.0, args.timeout_sec),
+        workers=max(1, args.workers),
+        cwd=args.cwd,
+    )
+    print(f"[openclaw-chat-adapter] listening on http://{args.host}:{args.port}")
+    print(
+        f"[openclaw-chat-adapter] workers={max(1, args.workers)} timeout_sec={max(5.0, args.timeout_sec)} cwd={args.cwd}"
+    )
+    if not args.no_warmup:
+        server.adapter.warmup()
+    server.serve_forever()
+
+
+if __name__ == "__main__":
+    main()

--- a/cloud/src/cli.rs
+++ b/cloud/src/cli.rs
@@ -14,7 +14,6 @@ pub(crate) fn print_usage(binary: &str) {
                [--ack-mismatch <payload>] [--ack-unknown-sensor <payload>]
                [--token-store <path>] [--registry <path>] [--database-url <dsn>]
                [--expected <legacy-payload>] [--ack-match <legacy-ack>]
-
   {binary} token [--config <path>] [--token-store <path>]
 
 Defaults:
@@ -29,10 +28,9 @@ Defaults:
   --database-url from CLI/env/config (required)
 
 Notes:
-  1) Default subcommand is 'run'.
-  2) Registration format: register:{{json}}
-  3) Data must include device_id=<id>.
-"
+  1) Default subcommand is `run`.
+  2) Registration packet format is `register:{{json}}`.
+  3) Telemetry payload should contain `device_id=<id>`, otherwise cloud may return `ack:unregistered`."
     );
 }
 

--- a/cloud/src/http_server.rs
+++ b/cloud/src/http_server.rs
@@ -30,6 +30,20 @@ const QUERY_CACHE_TTL_SECONDS: u64 = 15;
 const QUERY_CACHE_MAX_ENTRIES: usize = 500;
 const PERF_METRIC_WINDOW_SIZE: usize = 2048;
 
+fn env_usize(key: &str, default_value: usize) -> usize {
+    std::env::var(key)
+        .ok()
+        .and_then(|v| v.parse::<usize>().ok())
+        .unwrap_or(default_value)
+}
+
+fn env_u64(key: &str, default_value: u64) -> u64 {
+    std::env::var(key)
+        .ok()
+        .and_then(|v| v.parse::<u64>().ok())
+        .unwrap_or(default_value)
+}
+
 #[derive(Debug, Clone)]
 struct QueryCacheEntry {
     value: String,
@@ -346,17 +360,22 @@ pub fn start_http_server(
     )));
     let auth_enabled = auth_enabled_from_env();
     let perf = Arc::new(Mutex::new(PerfMetrics::new(PERF_METRIC_WINDOW_SIZE)));
+    let ai_timeout_sec = env_u64("CLOUD_HTTP_AI_TIMEOUT_SEC", 20);
+    let ai_pool_idle = env_usize("CLOUD_HTTP_AI_POOL_MAX_IDLE_PER_HOST", 8);
+    let openclaw_timeout_sec = env_u64("CLOUD_HTTP_OPENCLAW_TIMEOUT_SEC", 120);
+    let openclaw_pool_idle = env_usize("CLOUD_HTTP_OPENCLAW_POOL_MAX_IDLE_PER_HOST", 4);
+
     let ai_http_client = Arc::new(
         reqwest::blocking::Client::builder()
-            .timeout(Duration::from_secs(20))
-            .pool_max_idle_per_host(8)
+            .timeout(Duration::from_secs(ai_timeout_sec))
+            .pool_max_idle_per_host(ai_pool_idle)
             .build()
             .expect("Failed to build AI HTTP client"),
     );
     let openclaw_http_client = Arc::new(
         reqwest::blocking::Client::builder()
-            .timeout(Duration::from_secs(120))
-            .pool_max_idle_per_host(4)
+            .timeout(Duration::from_secs(openclaw_timeout_sec))
+            .pool_max_idle_per_host(openclaw_pool_idle)
             .build()
             .expect("Failed to build OpenClaw HTTP client"),
     );
@@ -370,6 +389,14 @@ pub fn start_http_server(
         "{} [cloud-http] auth_enabled={}",
         now_rfc3339(),
         auth_enabled
+    );
+    println!(
+        "{} [cloud-http] ai_timeout_sec={} ai_pool_idle={} openclaw_timeout_sec={} openclaw_pool_idle={}",
+        now_rfc3339(),
+        ai_timeout_sec,
+        ai_pool_idle,
+        openclaw_timeout_sec,
+        openclaw_pool_idle
     );
 
     thread::spawn(move || {


### PR DESCRIPTION
## Summary
- optimize chat adapter path for agent-AI latency stability
- add staircase chat stress CLI for hot frequency tuning
- make cloud HTTP client pool/timeout tunable by env
- document adapter perf knobs and chat stress commands

## Changes
- `cloud/scripts/openclaw_chat_adapter.py`
  - add bounded worker pool for CLI requests
  - add startup warmup and runtime knobs (`CHAT_ADAPTER_*`)
- `cloud/scripts/chat_stress_cli.py` (new)
  - continuous chat pressure loop
  - live control via control-file
  - staircase mode (every N seconds decrease interval by delta)
- `cloud/src/http_server.rs`
  - env-driven timeout/pool knobs for AI/OpenClaw HTTP clients
- `cloud/README.md`
  - usage docs for adapter knobs and chat stress CLI

## Verification
- `python -m py_compile cloud/scripts/openclaw_chat_adapter.py cloud/scripts/chat_stress_cli.py`
- pending follow-up in this branch: fix existing `cloud/src/cli.rs` encoding issue so `cargo check -p cloud` can pass

## Related
- issue #60