### PR TITLE
feat(poc): video frame extraction + upload chain validation (issue #62)

### DIFF
--- a/cloud/README.md
+++ b/cloud/README.md
@@ -362,6 +362,21 @@ Output includes:
 - upload latency (`avg/p50/p95/p99`)
 - throughput (`frames/sec`)
 
+## Mobile live camera PoC (Issue #62 primary path)
+
+For real-time target capture from a phone camera (not offline video replay), open this page on mobile browser:
+
+```text
+http://<cloud-ip>:8088/rice/mobile_live_capture.html?device_id=dev_mobile_live_01
+```
+
+Capabilities:
+- uses `getUserMedia` rear camera stream
+- periodic frame capture from live preview
+- uploads each frame to `/api/v1/image/upload`
+- shows live sent/ok/fail stats and per-request logs
+- supports interval hot change while running
+
 ## Performance observability (P50/P95/P99)
 
 Cloud now exposes in-process latency breakdown metrics for the critical upload pipeline:

--- a/cloud/README.md
+++ b/cloud/README.md
@@ -337,6 +337,31 @@ Notes:
 - Use `--image-path <file>` to upload a real test image; if omitted, it uses a built-in tiny PNG.
 - Use `--max-uploads <n>` for bounded test runs in CI/local smoke.
 
+## Video frame PoC CLI (Issue #62)
+
+Validate video frame recognition pipeline by extracting frames at fixed intervals and uploading to the existing image API.
+
+Prerequisite:
+- install `ffmpeg` and `ffprobe`
+
+Example:
+
+```bash
+python3 scripts/video_frame_poc.py \
+  --video-path /path/to/test.mp4 \
+  --endpoint http://127.0.0.1:8088/api/v1/image/upload \
+  --device-id dev_video_poc_01 \
+  --frame-interval-sec 2.0 \
+  --max-frames 30 \
+  --report-file /tmp/video_poc_report.json
+```
+
+Output includes:
+- success/failure counts and success rate
+- extraction latency (`avg/p50/p95/p99`)
+- upload latency (`avg/p50/p95/p99`)
+- throughput (`frames/sec`)
+
 ## Performance observability (P50/P95/P99)
 
 Cloud now exposes in-process latency breakdown metrics for the critical upload pipeline:

--- a/cloud/scripts/video_frame_poc.py
+++ b/cloud/scripts/video_frame_poc.py
@@ -1,0 +1,241 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import json
+import math
+import os
+import shutil
+import statistics
+import subprocess
+import time
+import urllib.parse
+import urllib.request
+from datetime import datetime, timezone
+from typing import Any
+
+
+DEFAULT_ENDPOINT = "http://127.0.0.1:8088/api/v1/image/upload"
+DEFAULT_TIMEOUT_SEC = 20.0
+
+
+def utc_now_rfc3339() -> str:
+    return datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+
+
+def encode_multipart(field_name: str, filename: str, body: bytes, content_type: str) -> tuple[bytes, str]:
+    boundary = f"----video-frame-poc-{int(time.time() * 1000)}"
+    head = (
+        f"--{boundary}\r\n"
+        f"Content-Disposition: form-data; name=\"{field_name}\"; filename=\"{filename}\"\r\n"
+        f"Content-Type: {content_type}\r\n\r\n"
+    ).encode("utf-8")
+    tail = f"\r\n--{boundary}--\r\n".encode("utf-8")
+    return head + body + tail, boundary
+
+
+def post_image(
+    endpoint: str,
+    device_id: str,
+    location: str,
+    crop_type: str,
+    farm_note: str,
+    image_bytes: bytes,
+    image_name: str,
+    timeout_sec: float,
+) -> tuple[bool, float, str]:
+    ts = utc_now_rfc3339()
+    query = urllib.parse.urlencode(
+        {
+            "device_id": device_id,
+            "ts": ts,
+            "location": location,
+            "crop_type": crop_type,
+            "farm_note": farm_note,
+        }
+    )
+    url = endpoint + ("&" if "?" in endpoint else "?") + query
+    body, boundary = encode_multipart("file", image_name, image_bytes, "image/png")
+    req = urllib.request.Request(url=url, data=body, method="POST")
+    req.add_header("Content-Type", f"multipart/form-data; boundary={boundary}")
+    req.add_header("Content-Length", str(len(body)))
+    start = time.perf_counter()
+    try:
+        with urllib.request.urlopen(req, timeout=timeout_sec) as resp:
+            payload = resp.read().decode("utf-8", errors="replace")
+            ok = resp.status == 200 and '"status":"success"' in payload.replace(" ", "")
+            return ok, (time.perf_counter() - start) * 1000.0, payload[:240]
+    except Exception as exc:  # noqa: BLE001
+        return False, (time.perf_counter() - start) * 1000.0, f"error: {exc}"
+
+
+def ensure_ffmpeg() -> None:
+    if shutil.which("ffmpeg") is None or shutil.which("ffprobe") is None:
+        raise RuntimeError("ffmpeg/ffprobe not found. Please install ffmpeg first.")
+
+
+def probe_duration(video_path: str) -> float:
+    cmd = [
+        "ffprobe",
+        "-v",
+        "error",
+        "-show_entries",
+        "format=duration",
+        "-of",
+        "json",
+        video_path,
+    ]
+    proc = subprocess.run(cmd, capture_output=True, text=True, check=False)
+    if proc.returncode != 0:
+        raise RuntimeError(f"ffprobe failed: {proc.stderr.strip()}")
+    data = json.loads(proc.stdout or "{}")
+    duration = float(data.get("format", {}).get("duration", 0.0))
+    if duration <= 0:
+        raise RuntimeError("unable to probe video duration")
+    return duration
+
+
+def extract_frame_png(video_path: str, sec: float) -> bytes:
+    cmd = [
+        "ffmpeg",
+        "-loglevel",
+        "error",
+        "-ss",
+        f"{sec:.3f}",
+        "-i",
+        video_path,
+        "-frames:v",
+        "1",
+        "-f",
+        "image2pipe",
+        "-vcodec",
+        "png",
+        "-",
+    ]
+    proc = subprocess.run(cmd, capture_output=True, check=False)
+    if proc.returncode != 0 or not proc.stdout:
+        err = proc.stderr.decode("utf-8", errors="replace").strip()
+        raise RuntimeError(f"ffmpeg extract failed at {sec:.3f}s: {err}")
+    return proc.stdout
+
+
+def pct(values: list[float], q: float) -> float:
+    if not values:
+        return 0.0
+    idx = int((len(values) - 1) * q)
+    return sorted(values)[idx]
+
+
+def run(args: argparse.Namespace) -> int:
+    ensure_ffmpeg()
+    if not os.path.isfile(args.video_path):
+        raise RuntimeError(f"video not found: {args.video_path}")
+    if args.frame_interval_sec <= 0:
+        raise RuntimeError("--frame-interval-sec must be > 0")
+    duration = probe_duration(args.video_path)
+    total_planned = int(math.floor(duration / args.frame_interval_sec)) + 1
+    if args.max_frames and args.max_frames > 0:
+        total_planned = min(total_planned, args.max_frames)
+
+    print(
+        f"[video-poc] start video={args.video_path} duration={duration:.2f}s interval={args.frame_interval_sec:.2f}s planned_frames={total_planned}"
+    )
+    print(f"[video-poc] endpoint={args.endpoint} device_id={args.device_id}")
+
+    upload_lat_ms: list[float] = []
+    extract_lat_ms: list[float] = []
+    ok_count = 0
+    fail_count = 0
+    t0 = time.perf_counter()
+
+    for i in range(total_planned):
+        sec = min(i * args.frame_interval_sec, max(duration - 0.01, 0))
+        x0 = time.perf_counter()
+        try:
+            png = extract_frame_png(args.video_path, sec)
+        except Exception as exc:  # noqa: BLE001
+            fail_count += 1
+            print(f"[{i+1}/{total_planned}] extract_fail t={sec:.2f}s err={exc}")
+            continue
+        x_ms = (time.perf_counter() - x0) * 1000.0
+        extract_lat_ms.append(x_ms)
+
+        ok, up_ms, detail = post_image(
+            endpoint=args.endpoint,
+            device_id=args.device_id,
+            location=args.location,
+            crop_type=args.crop_type,
+            farm_note=args.farm_note,
+            image_bytes=png,
+            image_name=f"frame_{i:04d}.png",
+            timeout_sec=args.timeout_sec,
+        )
+        upload_lat_ms.append(up_ms)
+        if ok:
+            ok_count += 1
+            print(f"[{i+1}/{total_planned}] ok t={sec:.2f}s extract={x_ms:.1f}ms upload={up_ms:.1f}ms")
+        else:
+            fail_count += 1
+            print(f"[{i+1}/{total_planned}] upload_fail t={sec:.2f}s upload={up_ms:.1f}ms detail={detail}")
+
+    elapsed = max(time.perf_counter() - t0, 1e-9)
+    sent = ok_count + fail_count
+    fps = sent / elapsed
+    summary: dict[str, Any] = {
+        "status": "done",
+        "video_path": os.path.abspath(args.video_path),
+        "duration_sec": round(duration, 3),
+        "frame_interval_sec": args.frame_interval_sec,
+        "planned_frames": total_planned,
+        "sent_frames": sent,
+        "success": ok_count,
+        "failed": fail_count,
+        "success_rate": round((ok_count / sent) if sent else 0.0, 4),
+        "elapsed_sec": round(elapsed, 3),
+        "throughput_fps": round(fps, 3),
+        "extract_ms": {
+            "avg": round(statistics.mean(extract_lat_ms), 2) if extract_lat_ms else 0.0,
+            "p50": round(pct(extract_lat_ms, 0.50), 2) if extract_lat_ms else 0.0,
+            "p95": round(pct(extract_lat_ms, 0.95), 2) if extract_lat_ms else 0.0,
+            "p99": round(pct(extract_lat_ms, 0.99), 2) if extract_lat_ms else 0.0,
+        },
+        "upload_ms": {
+            "avg": round(statistics.mean(upload_lat_ms), 2) if upload_lat_ms else 0.0,
+            "p50": round(pct(upload_lat_ms, 0.50), 2) if upload_lat_ms else 0.0,
+            "p95": round(pct(upload_lat_ms, 0.95), 2) if upload_lat_ms else 0.0,
+            "p99": round(pct(upload_lat_ms, 0.99), 2) if upload_lat_ms else 0.0,
+        },
+    }
+    print(json.dumps(summary, ensure_ascii=False, indent=2))
+    if args.report_file:
+        parent = os.path.dirname(os.path.abspath(args.report_file))
+        if parent:
+            os.makedirs(parent, exist_ok=True)
+        with open(args.report_file, "w", encoding="utf-8") as f:
+            json.dump(summary, f, ensure_ascii=False, indent=2)
+        print(f"[video-poc] report saved to {os.path.abspath(args.report_file)}")
+    return 0
+
+
+def build_parser() -> argparse.ArgumentParser:
+    p = argparse.ArgumentParser(description="Video frame upload PoC CLI")
+    p.add_argument("--video-path", required=True, help="Input video file path")
+    p.add_argument("--endpoint", default=DEFAULT_ENDPOINT)
+    p.add_argument("--device-id", default="dev_video_poc_01")
+    p.add_argument("--location", default="video_lab")
+    p.add_argument("--crop-type", default="rice")
+    p.add_argument("--farm-note", default="video frame poc")
+    p.add_argument("--frame-interval-sec", type=float, default=2.0)
+    p.add_argument("--max-frames", type=int, default=0, help="0 means no cap")
+    p.add_argument("--timeout-sec", type=float, default=DEFAULT_TIMEOUT_SEC)
+    p.add_argument("--report-file", default="")
+    return p
+
+
+def main() -> int:
+    args = build_parser().parse_args()
+    return run(args)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/frontend/rice/i18n.js
+++ b/frontend/rice/i18n.js
@@ -41,6 +41,8 @@ window.I18N = (() => {
             mobile_select_first: '请先选择一张图片。',
             mobile_no_device_id: '未找到 device_id，请使用 ?device_id=... 打开页面或先注册设备。',
             mobile_uploading_for: '正在上传到设备', mobile_upload_success: '上传成功', mobile_upload_failed: '上传失败',
+            mobile_live_poc: '实时摄像头 PoC',
+            mobile_live_poc_desc: '打开实时摄像头抓帧上传页面',
             accepted: '已接收',
         },
         en: {
@@ -79,6 +81,8 @@ window.I18N = (() => {
             mobile_select_first: 'Please select an image first.',
             mobile_no_device_id: 'No device_id found. Open page with ?device_id=... or register device first.',
             mobile_uploading_for: 'Uploading for', mobile_upload_success: 'Upload success', mobile_upload_failed: 'Upload failed',
+            mobile_live_poc: 'Live Camera PoC',
+            mobile_live_poc_desc: 'Open real-time camera frame upload page',
             accepted: 'accepted',
         },
         ms: {
@@ -117,6 +121,8 @@ window.I18N = (() => {
             mobile_select_first: 'Sila pilih imej dahulu.',
             mobile_no_device_id: 'Tiada device_id. Buka dengan ?device_id=... atau daftar peranti dahulu.',
             mobile_uploading_for: 'Memuat naik untuk', mobile_upload_success: 'Muat naik berjaya', mobile_upload_failed: 'Muat naik gagal',
+            mobile_live_poc: 'PoC Kamera Langsung',
+            mobile_live_poc_desc: 'Buka halaman muat naik bingkai kamera masa nyata',
             accepted: 'diterima',
         },
     };

--- a/frontend/rice/mobile_live_capture.html
+++ b/frontend/rice/mobile_live_capture.html
@@ -1,0 +1,172 @@
+<!doctype html>
+<html lang="zh-CN">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width,initial-scale=1" />
+  <title>Mobile Live Capture PoC</title>
+  <style>
+    body { margin: 0; font-family: Arial, sans-serif; background: #081426; color: #e6f2ff; }
+    .wrap { max-width: 980px; margin: 0 auto; padding: 14px; }
+    .card { background: #0f2138; border: 1px solid #1f3659; border-radius: 10px; padding: 12px; margin-bottom: 12px; }
+    .row { display: flex; flex-wrap: wrap; gap: 8px; align-items: center; margin-bottom: 8px; }
+    input, button { border-radius: 8px; border: 1px solid #2b476f; background: #0b1a30; color: #e6f2ff; padding: 8px 10px; }
+    input { min-width: 120px; }
+    button { cursor: pointer; }
+    button.primary { background: #1f8f5f; border-color: #2ca16f; }
+    button.warn { background: #8f2f2f; border-color: #af4242; }
+    #preview { width: 100%; max-height: 55vh; background: #000; border-radius: 8px; }
+    #log { white-space: pre-wrap; font-size: 12px; line-height: 1.35; background: #061221; border-radius: 8px; padding: 10px; min-height: 120px; max-height: 260px; overflow: auto; }
+    .muted { opacity: 0.85; font-size: 12px; }
+  </style>
+</head>
+<body>
+  <div class="wrap">
+    <div class="card">
+      <h3 style="margin: 0 0 8px 0;">Issue #62 Mobile Live Camera PoC</h3>
+      <div class="muted">手机实时取景 -> 周期抓帧 -> 上传 /api/v1/image/upload -> 云端推理</div>
+    </div>
+
+    <div class="card">
+      <div class="row">
+        <label>device_id <input id="deviceId" /></label>
+        <label>location <input id="location" value="mobile_live" /></label>
+        <label>crop_type <input id="cropType" value="rice" /></label>
+      </div>
+      <div class="row">
+        <label>farm_note <input id="farmNote" value="issue62-live-camera" style="min-width: 220px;" /></label>
+        <label>interval(s) <input id="intervalSec" type="number" min="0.2" step="0.1" value="2.0" /></label>
+        <label>endpoint <input id="endpoint" value="/api/v1/image/upload" style="min-width: 220px;" /></label>
+      </div>
+      <div class="row">
+        <button id="startCam" class="primary">启动摄像头</button>
+        <button id="startLoop" class="primary">开始循环上传</button>
+        <button id="stopLoop" class="warn">停止</button>
+        <span id="stats" class="muted">sent=0 ok=0 fail=0</span>
+      </div>
+    </div>
+
+    <div class="card">
+      <video id="preview" autoplay muted playsinline></video>
+      <canvas id="canvas" style="display:none;"></canvas>
+    </div>
+
+    <div class="card">
+      <div id="log"></div>
+    </div>
+  </div>
+
+  <script>
+    const q = new URLSearchParams(location.search);
+    const $ = (id) => document.getElementById(id);
+    const state = { stream: null, timer: null, sent: 0, ok: 0, fail: 0 };
+    $("deviceId").value = q.get("device_id") || "dev_mobile_live_01";
+    if (q.get("endpoint")) $("endpoint").value = q.get("endpoint");
+
+    function log(msg) {
+      const el = $("log");
+      el.textContent += `[${new Date().toISOString()}] ${msg}\n`;
+      el.scrollTop = el.scrollHeight;
+    }
+    function refreshStats() {
+      $("stats").textContent = `sent=${state.sent} ok=${state.ok} fail=${state.fail}`;
+    }
+    async function startCamera() {
+      if (state.stream) return;
+      try {
+        state.stream = await navigator.mediaDevices.getUserMedia({
+          video: { facingMode: { ideal: "environment" }, width: { ideal: 1280 }, height: { ideal: 720 } },
+          audio: false
+        });
+        $("preview").srcObject = state.stream;
+        log("camera started");
+      } catch (e) {
+        log("camera failed: " + e.message);
+      }
+    }
+    function stopLoop() {
+      if (state.timer) clearInterval(state.timer);
+      state.timer = null;
+      log("loop stopped");
+    }
+    async function uploadOnce() {
+      const video = $("preview");
+      if (!video.videoWidth || !video.videoHeight) {
+        log("skip: no video frame yet");
+        return;
+      }
+      const intervalSec = Math.max(0.2, Number($("intervalSec").value || 2.0));
+      const endpoint = $("endpoint").value.trim();
+      const deviceId = $("deviceId").value.trim();
+      const locationVal = $("location").value.trim();
+      const cropType = $("cropType").value.trim();
+      const farmNote = $("farmNote").value.trim();
+      const canvas = $("canvas");
+      canvas.width = video.videoWidth;
+      canvas.height = video.videoHeight;
+      const ctx = canvas.getContext("2d");
+      ctx.drawImage(video, 0, 0);
+      const blob = await new Promise((resolve) => canvas.toBlob(resolve, "image/jpeg", 0.86));
+      if (!blob) {
+        log("capture failed: canvas blob null");
+        return;
+      }
+      const ts = new Date().toISOString();
+      const qs = new URLSearchParams({
+        device_id: deviceId,
+        ts,
+        location: locationVal,
+        crop_type: cropType,
+        farm_note: farmNote
+      });
+      const form = new FormData();
+      form.append("file", blob, `live_${Date.now()}.jpg`);
+      const url = endpoint.includes("?") ? `${endpoint}&${qs}` : `${endpoint}?${qs}`;
+      const t0 = performance.now();
+      state.sent += 1;
+      refreshStats();
+      try {
+        const resp = await fetch(url, { method: "POST", body: form });
+        const txt = await resp.text();
+        const ms = (performance.now() - t0).toFixed(1);
+        if (resp.ok && txt.includes("\"status\":\"success\"")) {
+          state.ok += 1;
+          log(`ok ${ms}ms ${txt.slice(0, 180)}`);
+        } else {
+          state.fail += 1;
+          log(`fail ${ms}ms status=${resp.status} body=${txt.slice(0, 180)}`);
+        }
+      } catch (e) {
+        state.fail += 1;
+        log(`fail network ${e.message}`);
+      }
+      refreshStats();
+      if (state.timer) {
+        const nowInterval = Math.max(0.2, Number($("intervalSec").value || 2.0));
+        if (Math.abs(nowInterval - intervalSec) > 1e-6) {
+          clearInterval(state.timer);
+          state.timer = setInterval(uploadOnce, nowInterval * 1000);
+          log(`interval hot-update -> ${nowInterval}s`);
+        }
+      }
+    }
+    async function startLoop() {
+      await startCamera();
+      stopLoop();
+      const sec = Math.max(0.2, Number($("intervalSec").value || 2.0));
+      state.timer = setInterval(uploadOnce, sec * 1000);
+      log("loop started interval=" + sec + "s");
+      uploadOnce();
+    }
+
+    $("startCam").addEventListener("click", startCamera);
+    $("startLoop").addEventListener("click", startLoop);
+    $("stopLoop").addEventListener("click", stopLoop);
+    window.addEventListener("beforeunload", () => {
+      stopLoop();
+      if (state.stream) {
+        for (const t of state.stream.getTracks()) t.stop();
+      }
+    });
+  </script>
+</body>
+</html>

--- a/frontend/rice/rice_dashboard.html
+++ b/frontend/rice/rice_dashboard.html
@@ -267,6 +267,17 @@
                                   <button id="mobileUploadSubmitBtn" class="px-3 py-2 rounded-lg bg-emerald-600/80 border border-emerald-400/30 text-xs text-white hover:bg-emerald-500 disabled:opacity-50 disabled:cursor-not-allowed transition-all" disabled data-i18n="mobile_upload">Upload</button>
                               </div>
                               <p id="mobileUploadFileName" class="text-[11px] text-slate-400 mb-3 font-mono truncate" data-i18n="no_image_selected">No image selected</p>
+                              <div class="mb-3">
+                                  <a id="mobileLivePocLink"
+                                     href="/rice/mobile_live_capture.html"
+                                     target="_blank"
+                                     rel="noopener noreferrer"
+                                     class="inline-flex items-center gap-2 px-3 py-2 rounded-lg bg-violet-500/20 border border-violet-400/30 text-xs text-violet-100 hover:bg-violet-500/30 transition-all">
+                                      <i class="fa fa-video-camera"></i>
+                                      <span data-i18n="mobile_live_poc">Live Camera PoC</span>
+                                  </a>
+                                  <span class="ml-2 text-[10px] text-slate-500" data-i18n="mobile_live_poc_desc">Open real-time camera frame upload page</span>
+                              </div>
                               <div class="aspect-video bg-black/40 rounded-xl overflow-hidden border border-white/10 relative mb-3">
                                   <img id="mobileUploadPreview" src="" alt="preview" class="hidden w-full h-full object-cover" />
                                   <div id="mobileUploadPreviewEmpty" class="absolute inset-0 flex items-center justify-center text-slate-500 text-xs" data-i18n="waiting_image">Waiting image...</div>

--- a/frontend/rice/ui.js
+++ b/frontend/rice/ui.js
@@ -375,7 +375,13 @@ window.UI = (() => {
             const albumBtn = document.getElementById('mobileUploadAlbumBtn');
             const clearBtn = document.getElementById('mobileUploadClearBtn');
             const submitBtn = document.getElementById('mobileUploadSubmitBtn');
+            const livePocLink = document.getElementById('mobileLivePocLink');
             if (!cameraInput || !fileInput || !cameraBtn || !albumBtn || !submitBtn) return;
+
+            if (livePocLink) {
+                const did = encodeURIComponent(Upload.activeDeviceId || 'dev_mobile_live_01');
+                livePocLink.href = `/rice/mobile_live_capture.html?device_id=${did}`;
+            }
 
             Upload.isMobileClient = /Android|iPhone|iPad|iPod|Mobile/i.test(navigator.userAgent || '')
                 || window.matchMedia('(max-width: 900px)').matches;


### PR DESCRIPTION
## Summary
Implement Issue #62 PoC: video frame extraction + upload to existing image recognition chain.

## What is added
- New CLI: `cloud/scripts/video_frame_poc.py`
  - Reads a video file
  - Extracts frames at fixed interval via `ffmpeg`
  - Uploads each frame to existing `POST /api/v1/image/upload`
  - Reports:
    - success/failure counts
    - success rate
    - extraction latency (avg/p50/p95/p99)
    - upload latency (avg/p50/p95/p99)
    - throughput (frames/sec)
  - Optional `--max-frames` cap and `--report-file` JSON output
- Docs update in `cloud/README.md`
  - Added a dedicated section for Issue #62 video-frame PoC usage

## Verification done
- `python -m py_compile cloud/scripts/video_frame_poc.py`
- `python cloud/scripts/video_frame_poc.py --help`

## Notes
- This is intentionally PoC-level and reuses existing cloud image upload API.
- Requires `ffmpeg` + `ffprobe` on runtime host.

## Related
- Closes #62