### PR TITLE
feat(ai): oil-palm v1 route + prediction contract (issue 65, clean branch)

### DIFF
--- a/ai_engine/README.md
+++ b/ai_engine/README.md
@@ -88,3 +88,15 @@ CROP_PROFILE=oil_palm uvicorn ai_engine.main:app --reload --host 0.0.0.0 --port 
 python -m ai_engine.infer --help
 python -m ai_engine.infer --image-path test.jpg
 ```
+## Oil Palm V1 additions (Issue #65)
+
+- `GET /api/v1/oil-palm/route`
+  - capability roadmap payload for:
+    - disease_analysis
+    - growth_analysis
+    - weather_prediction
+    - yield_assessment
+- `POST /api/v1/oil-palm/predict-v1`
+  - stable v1 inference contract with frontend-friendly metadata fields.
+
+See `doc/issue65_oil_palm_v1_plan.md` for details and quick validation commands.

--- a/ai_engine/common/adapters/image_adapter.py
+++ b/ai_engine/common/adapters/image_adapter.py
@@ -1,0 +1,16 @@
+﻿from __future__ import annotations
+
+import imghdr
+
+
+class ImageLoadError(ValueError):
+    """Raised when image bytes cannot be decoded."""
+
+
+def validate_image_bytes(image_bytes: bytes) -> str:
+    if not image_bytes:
+        raise ImageLoadError("empty image bytes")
+    kind = imghdr.what(None, h=image_bytes)
+    if kind is None:
+        raise ImageLoadError("unsupported or invalid image bytes")
+    return kind

--- a/ai_engine/common/health.py
+++ b/ai_engine/common/health.py
@@ -1,0 +1,16 @@
+﻿from __future__ import annotations
+
+from datetime import datetime, timezone
+
+from fastapi import APIRouter
+
+router = APIRouter()
+
+
+@router.get("/health")
+def health() -> dict:
+    return {
+        "status": "ok",
+        "service": "ai_engine",
+        "ts": datetime.now(timezone.utc).isoformat(),
+    }

--- a/ai_engine/common/schemas/prediction.py
+++ b/ai_engine/common/schemas/prediction.py
@@ -1,0 +1,19 @@
+﻿from __future__ import annotations
+
+from typing import Any
+
+from pydantic import BaseModel, Field
+
+
+class TopKItem(BaseModel):
+    predicted_class: str
+    confidence: float = Field(ge=0.0, le=1.0)
+
+
+class PredictionResponse(BaseModel):
+    status: str = "success"
+    predicted_class: str
+    confidence: float = Field(ge=0.0, le=1.0)
+    model_version: str
+    topk: list[TopKItem] = Field(default_factory=list)
+    metadata: dict[str, Any] = Field(default_factory=dict)

--- a/ai_engine/crops/oil_palm/inference/api.py
+++ b/ai_engine/crops/oil_palm/inference/api.py
@@ -1,0 +1,133 @@
+﻿from __future__ import annotations
+
+from datetime import datetime, timezone
+from typing import Literal
+
+from fastapi import APIRouter, File, Form, UploadFile
+from pydantic import BaseModel, Field
+
+from ai_engine.common.adapters.image_adapter import validate_image_bytes
+from ai_engine.common.schemas.prediction import PredictionResponse
+from ai_engine.crops.oil_palm.inference.predictor import analyze_oil_palm_image
+
+router = APIRouter()
+
+
+class CapabilityItem(BaseModel):
+    capability: str
+    v1_scope: str
+    input_contract: str
+    output_fields: list[str]
+    metric: str
+
+
+class RouteDoc(BaseModel):
+    crop: Literal["oil_palm"] = "oil_palm"
+    version: str = "v1"
+    updated_at: str
+    capabilities: list[CapabilityItem]
+
+
+@router.get("/oil-palm/route")
+def oil_palm_route() -> dict:
+    payload = RouteDoc(
+        updated_at=datetime.now(timezone.utc).isoformat(),
+        capabilities=[
+            CapabilityItem(
+                capability="disease_analysis",
+                v1_scope="single-frame frond risk classification",
+                input_contract="multipart image file",
+                output_fields=["predicted_class", "confidence", "metadata.disease_rate", "metadata.is_diseased"],
+                metric="top1 confidence / disease_rate",
+            ),
+            CapabilityItem(
+                capability="growth_analysis",
+                v1_scope="derive growth vigor from image risk",
+                input_contract="multipart image file",
+                output_fields=["metadata.growth_vigor_index"],
+                metric="growth_vigor_index",
+            ),
+            CapabilityItem(
+                capability="weather_prediction",
+                v1_scope="risk proxy based on current visual stress",
+                input_contract="multipart image file + optional weather text",
+                output_fields=["metadata.weather_risk_score"],
+                metric="weather_risk_score",
+            ),
+            CapabilityItem(
+                capability="yield_assessment",
+                v1_scope="yield risk proxy based on disease and growth",
+                input_contract="multipart image file",
+                output_fields=["metadata.yield_risk_score"],
+                metric="yield_risk_score",
+            ),
+        ],
+    )
+    return payload.model_dump()
+
+
+@router.post("/oil-palm/predict-v1")
+async def oil_palm_predict_v1(
+    file: UploadFile = File(...),
+    location: str = Form(default="unknown_location"),
+    plantation_id: str = Form(default="unknown_plantation"),
+) -> dict:
+    image_bytes = await file.read()
+    validate_image_bytes(image_bytes)
+    raw = analyze_oil_palm_image(image_bytes)
+
+    # attach self-explaining context for frontend direct rendering
+    raw.setdefault("metadata", {})
+    raw["metadata"].update(
+        {
+            "crop": "oil_palm",
+            "location": location,
+            "plantation_id": plantation_id,
+            "capability_bundle": [
+                "disease_analysis",
+                "growth_analysis",
+                "weather_prediction",
+                "yield_assessment",
+            ],
+        }
+    )
+    return PredictionResponse(
+        predicted_class=raw["predicted_class"],
+        confidence=raw["confidence"],
+        model_version=raw["model_version"],
+        topk=raw.get("topk", []),
+        metadata=raw.get("metadata", {}),
+    ).model_dump()
+
+
+@router.post("/oil-palm/analyze-image")
+async def analyze_image(file: UploadFile = File(...)) -> dict:
+    image_bytes = await file.read()
+    validate_image_bytes(image_bytes)
+    return analyze_oil_palm_image(image_bytes)
+
+
+@router.post("/oil-palm/analyze-session")
+def analyze_session(session_id: str = Form(...), frame_count: int = Form(default=0)) -> dict:
+    return {
+        "status": "success",
+        "session_id": session_id,
+        "frame_count": frame_count,
+        "summary": {
+            "dominant_risk": "frond_nutrient_stress",
+            "recommendation": "inspect nutrient balance and leaf lesions",
+        },
+    }
+
+
+@router.post("/oil-palm/analyze-uav-mission")
+def analyze_uav_mission(mission_id: str = Form(...), image_count: int = Form(default=0)) -> dict:
+    return {
+        "status": "success",
+        "mission_id": mission_id,
+        "image_count": image_count,
+        "result": {
+            "hotspots": max(image_count // 5, 1) if image_count else 0,
+            "risk_level": "medium" if image_count > 0 else "unknown",
+        },
+    }

--- a/ai_engine/crops/oil_palm/inference/predictor.py
+++ b/ai_engine/crops/oil_palm/inference/predictor.py
@@ -1,0 +1,30 @@
+﻿from __future__ import annotations
+
+import hashlib
+
+
+def analyze_oil_palm_image(image_bytes: bytes) -> dict:
+    digest = hashlib.md5(image_bytes).hexdigest()
+    idx = int(digest[:2], 16) % 3
+    classes = ["frond_healthy", "frond_nutrient_stress", "frond_suspected_blight"]
+    predicted = classes[idx]
+    conf = 0.58 + (int(digest[2:4], 16) / 255.0) * 0.4
+    disease_risk = round(min(max(conf - 0.15, 0.1), 0.98), 4)
+
+    return {
+        "predicted_class": predicted,
+        "confidence": round(min(conf, 0.99), 4),
+        "model_version": "oil_palm_mock_v1",
+        "topk": [
+            {"predicted_class": predicted, "confidence": round(min(conf, 0.99), 4)},
+            {"predicted_class": classes[(idx + 1) % 3], "confidence": 0.2},
+        ],
+        "metadata": {
+            "disease_rate": disease_risk,
+            "is_diseased": predicted != "frond_healthy",
+            "growth_vigor_index": round(1.0 - disease_risk * 0.6, 4),
+            "weather_risk_score": round(0.35 + disease_risk * 0.3, 4),
+            "yield_risk_score": round(0.25 + disease_risk * 0.5, 4),
+            "advice_code": "inspect_nutrients" if predicted != "frond_healthy" else "normal_monitoring",
+        },
+    }

--- a/ai_engine/crops/rice/inference/api.py
+++ b/ai_engine/crops/rice/inference/api.py
@@ -1,0 +1,58 @@
+﻿from __future__ import annotations
+
+from fastapi import APIRouter, File, UploadFile
+
+from ai_engine.common.adapters.image_adapter import validate_image_bytes
+from ai_engine.common.schemas.prediction import PredictionResponse
+
+router = APIRouter()
+_classifier = None
+
+
+def set_classifier(classifier) -> None:
+    global _classifier
+    _classifier = classifier
+
+
+def _predict(image_bytes: bytes) -> PredictionResponse:
+    validate_image_bytes(image_bytes)
+    if _classifier is not None:
+        raw = _classifier.predict_bytes(image_bytes)
+    else:
+        raw = {
+            "predicted_class": "Healthy",
+            "confidence": 0.82,
+            "model_version": "rice_mock_v0",
+            "topk": [{"predicted_class": "Healthy", "confidence": 0.82}],
+            "metadata": {"advice_code": "normal_monitoring", "disease_rate": 0.12, "is_diseased": False},
+        }
+    return PredictionResponse(
+        predicted_class=raw["predicted_class"],
+        confidence=raw["confidence"],
+        model_version=raw["model_version"],
+        topk=raw.get("topk", []),
+        metadata=raw.get("metadata", {}),
+    )
+
+
+@router.post("/predict", include_in_schema=False)
+async def predict_legacy(file: UploadFile = File(...)) -> dict:
+    image_bytes = await file.read()
+    result = _predict(image_bytes)
+    return result.model_dump()
+
+
+@router.post("/rice/predict")
+async def predict_rice(file: UploadFile = File(...)) -> dict:
+    image_bytes = await file.read()
+    result = _predict(image_bytes)
+    return result.model_dump()
+
+
+@router.get("/rice/health")
+def rice_health() -> dict:
+    return {
+        "status": "ok",
+        "profile": "rice",
+        "model_loaded": _classifier is not None,
+    }

--- a/ai_engine/crops/rice/inference/rice_leaf_classifier.py
+++ b/ai_engine/crops/rice/inference/rice_leaf_classifier.py
@@ -1,0 +1,37 @@
+﻿from __future__ import annotations
+
+import hashlib
+
+
+class RiceLeafClassifier:
+    """Lightweight deterministic mock classifier for service continuity."""
+
+    def __init__(self, checkpoint_path: str, labels_file: str, config_file: str, advice_file: str) -> None:
+        self.checkpoint_path = checkpoint_path
+        self.labels_file = labels_file
+        self.config_file = config_file
+        self.advice_file = advice_file
+        self.model_version = "rice_mock_v1"
+        self.labels = ["Healthy", "Leaf_Blast", "Leaf_Scald"]
+
+    def predict_bytes(self, image_bytes: bytes) -> dict:
+        digest = hashlib.sha1(image_bytes).hexdigest()
+        idx = int(digest[:2], 16) % len(self.labels)
+        confidence = 0.62 + (int(digest[2:4], 16) / 255.0) * 0.36
+        predicted = self.labels[idx]
+        topk = [
+            {"predicted_class": predicted, "confidence": round(min(confidence, 0.99), 4)},
+            {"predicted_class": self.labels[(idx + 1) % len(self.labels)], "confidence": 0.2},
+        ]
+        metadata = {
+            "advice_code": "inspect_leaf" if predicted != "Healthy" else "normal_monitoring",
+            "disease_rate": round(topk[0]["confidence"] if predicted != "Healthy" else 0.12, 4),
+            "is_diseased": predicted != "Healthy",
+        }
+        return {
+            "predicted_class": predicted,
+            "confidence": topk[0]["confidence"],
+            "model_version": self.model_version,
+            "topk": topk,
+            "metadata": metadata,
+        }

--- a/doc/issue65_oil_palm_v1_plan.md
+++ b/doc/issue65_oil_palm_v1_plan.md
@@ -1,0 +1,49 @@
+# Issue #65 Delivery: Oil Palm AI Route + V1
+
+## Scope delivered
+- Capability route endpoint:
+  - `GET /api/v1/oil-palm/route`
+- V1 callable endpoint:
+  - `POST /api/v1/oil-palm/predict-v1`
+- Existing mock compatibility endpoints retained:
+  - `POST /api/v1/oil-palm/analyze-image`
+  - `POST /api/v1/oil-palm/analyze-session`
+  - `POST /api/v1/oil-palm/analyze-uav-mission`
+
+## Capability route (v1)
+The route endpoint defines four capability lanes and their contracts:
+1. `disease_analysis`
+2. `growth_analysis`
+3. `weather_prediction`
+4. `yield_assessment`
+
+## V1 output contract (frontend-friendly)
+`/oil-palm/predict-v1` returns:
+- `predicted_class`
+- `confidence`
+- `model_version`
+- `topk[]`
+- `metadata` with:
+  - `disease_rate`
+  - `is_diseased`
+  - `growth_vigor_index`
+  - `weather_risk_score`
+  - `yield_risk_score`
+  - `crop`
+  - `location`
+  - `plantation_id`
+  - `capability_bundle[]`
+
+## Quick validation
+```bash
+uvicorn ai_engine.main:app --host 0.0.0.0 --port 8000
+curl -s http://127.0.0.1:8000/api/v1/oil-palm/route
+curl -s -X POST http://127.0.0.1:8000/api/v1/oil-palm/predict-v1 \
+  -F "file=@test.jpg" \
+  -F "location=sector_01" \
+  -F "plantation_id=plm_demo_01"
+```
+
+## Notes
+- Current implementation is deterministic mock logic for v1 contract stability.
+- It is ready for replacement by real model inference without changing API schema.


### PR DESCRIPTION
## Summary
This PR delivers Issue #65 on a clean branch line, without touching collaborator branches.

Implemented an initial **oil-palm v1 callable contract** and completed missing AI-engine skeleton files so the service can expose stable endpoints for integration.

## What changed
- Added common health endpoint and prediction schema models.
- Added image-bytes validation adapter.
- Completed rice inference mock classifier + API wiring for compatibility.
- Added oil-palm capability route endpoint:
  - `GET /api/v1/oil-palm/route`
- Added oil-palm v1 prediction endpoint:
  - `POST /api/v1/oil-palm/predict-v1`
- Kept and completed compatible mock analysis endpoints:
  - `analyze-image`, `analyze-session`, `analyze-uav-mission`
- Added docs:
  - `doc/issue65_oil_palm_v1_plan.md`
  - README section for issue65 additions.

## Validation
- `python -m py_compile` passed for all newly changed Python files.
- Runtime FastAPI boot is not validated in this environment due to missing local dependency (`fastapi`).

## Notes
- This branch is intentionally clean: based on `dev` + one issue65 commit only.
