### PR TITLE
feat(tree-profile): add Tree Profile page, Tree List, and enhanced tr…

### DIFF
--- a/cloud/src/db.rs
+++ b/cloud/src/db.rs
@@ -1033,7 +1033,16 @@ impl DbManager {
 
     pub(crate) fn get_tree_by_code(&mut self, tree_code: &str) -> Result<Option<serde_json::Value>, String> {
         let rows = self.client.query(
-            "SELECT id, tree_code, species, current_status, crown_center_x, crown_center_y FROM trees WHERE tree_code = $1",
+            "SELECT t.id, t.tree_code, t.species, t.current_status, \
+                    t.coordinate_x, t.coordinate_y, t.crown_center_x, t.crown_center_y, \
+                    t.barcode_value, t.manual_verified, t.block_id, \
+                    t.source_orthomosaic_id, t.created_at, t.updated_at, \
+                    p.name AS plantation_name, p.crop_type AS plantation_crop_type, \
+                    o.image_url AS source_ortho_url \
+             FROM trees t \
+             LEFT JOIN plantations p ON t.plantation_id = p.id \
+             LEFT JOIN uav_orthomosaics o ON t.source_orthomosaic_id = o.id \
+             WHERE t.tree_code = $1",
             &[&tree_code],
         ).map_err(|e| format!("get_tree_by_code error: {}", e))?;
         if rows.is_empty() { return Ok(None); }
@@ -1042,16 +1051,146 @@ impl DbManager {
         let code: String = r.get("tree_code");
         let species: String = r.get("species");
         let status: String = r.get("current_status");
+        let coord_x: Option<f64> = r.get("coordinate_x");
+        let coord_y: Option<f64> = r.get("coordinate_y");
         let cx: Option<f64> = r.get("crown_center_x");
         let cy: Option<f64> = r.get("crown_center_y");
+        let barcode: Option<String> = r.get("barcode_value");
+        let verified: bool = r.get("manual_verified");
+        let block_id: Option<String> = r.get("block_id");
+        let source_ortho_id: Option<i32> = r.get("source_orthomosaic_id");
+        let plantation_name: Option<String> = r.get("plantation_name");
+        let plantation_crop: Option<String> = r.get("plantation_crop_type");
+        let ortho_url: Option<String> = r.get("source_ortho_url");
+        let created_at: chrono::DateTime<chrono::Utc> = r.get("created_at");
+        let updated_at: chrono::DateTime<chrono::Utc> = r.get("updated_at");
         Ok(Some(serde_json::json!({
             "id": id,
             "tree_code": code,
             "species": species,
             "current_status": status,
+            "coordinate_x": coord_x,
+            "coordinate_y": coord_y,
             "crown_center_x": cx,
-            "crown_center_y": cy
+            "crown_center_y": cy,
+            "barcode_value": barcode,
+            "manual_verified": verified,
+            "block_id": block_id,
+            "source_orthomosaic_id": source_ortho_id,
+            "plantation_name": plantation_name,
+            "plantation_crop_type": plantation_crop,
+            "source_ortho_url": ortho_url,
+            "created_at": created_at.to_rfc3339(),
+            "updated_at": updated_at.to_rfc3339()
         })))
+    }
+
+    pub(crate) fn list_trees_by_plantation(&mut self, plantation_id: i32, limit: i64, offset: i64) -> Result<Vec<serde_json::Value>, String> {
+        let rows = self.client.query(
+            "SELECT id, tree_code, species, current_status, coordinate_x, coordinate_y, \
+                    barcode_value, manual_verified, created_at \
+             FROM trees WHERE plantation_id = $1 ORDER BY tree_code LIMIT $2 OFFSET $3",
+            &[&plantation_id, &limit, &offset],
+        ).map_err(|e| format!("list_trees_by_plantation error: {}", e))?;
+        let mut out = Vec::new();
+        for r in rows {
+            let id: i32 = r.get("id");
+            let code: String = r.get("tree_code");
+            let species: String = r.get("species");
+            let status: String = r.get("current_status");
+            let cx: Option<f64> = r.get("coordinate_x");
+            let cy: Option<f64> = r.get("coordinate_y");
+            let barcode: Option<String> = r.get("barcode_value");
+            let verified: bool = r.get("manual_verified");
+            let created_at: chrono::DateTime<chrono::Utc> = r.get("created_at");
+            out.push(serde_json::json!({
+                "id": id,
+                "tree_code": code,
+                "species": species,
+                "current_status": status,
+                "coordinate_x": cx,
+                "coordinate_y": cy,
+                "barcode_value": barcode,
+                "manual_verified": verified,
+                "created_at": created_at.to_rfc3339()
+            }));
+        }
+        Ok(out)
+    }
+
+    pub(crate) fn count_trees_by_plantation(&mut self, plantation_id: i32) -> Result<i64, String> {
+        let row = self.client.query_one(
+            "SELECT COUNT(*) FROM trees WHERE plantation_id = $1",
+            &[&plantation_id],
+        ).map_err(|e| format!("count_trees_by_plantation error: {}", e))?;
+        Ok(row.get(0))
+    }
+
+    pub(crate) fn update_tree_status(&mut self, tree_code: &str, status: &str) -> Result<(), String> {
+        let affected = self.client.execute(
+            "UPDATE trees SET current_status = $1, updated_at = NOW() WHERE tree_code = $2",
+            &[&status, &tree_code],
+        ).map_err(|e| format!("update_tree_status error: {}", e))?;
+        if affected == 0 {
+            return Err("tree not found".to_string());
+        }
+        Ok(())
+    }
+
+    pub(crate) fn get_tree_timeline(&mut self, tree_code: &str) -> Result<Vec<serde_json::Value>, String> {
+        let rows = self.client.query(
+            "SELECT h.id, h.detected_x, h.detected_y, h.center_shift, h.match_confidence, \
+                    h.created_at, m.mission_name, m.captured_at AS mission_date \
+             FROM tree_coordinate_history h \
+             JOIN uav_missions m ON h.mission_id = m.id \
+             JOIN trees t ON h.tree_id = t.id \
+             WHERE t.tree_code = $1 \
+             ORDER BY h.created_at DESC",
+            &[&tree_code],
+        ).map_err(|e| format!("get_tree_timeline error: {}", e))?;
+        let mut out = Vec::new();
+        for r in rows {
+            let id: i32 = r.get("id");
+            let dx: Option<f64> = r.get("detected_x");
+            let dy: Option<f64> = r.get("detected_y");
+            let shift: Option<f64> = r.get("center_shift");
+            let conf: Option<f64> = r.get("match_confidence");
+            let created_at: chrono::DateTime<chrono::Utc> = r.get("created_at");
+            let mission_name: String = r.get("mission_name");
+            let mission_date: Option<chrono::DateTime<chrono::Utc>> = r.get("mission_date");
+            out.push(serde_json::json!({
+                "id": id,
+                "detected_x": dx,
+                "detected_y": dy,
+                "center_shift": shift,
+                "match_confidence": conf,
+                "mission_name": mission_name,
+                "mission_date": mission_date.map(|d| d.to_rfc3339()),
+                "created_at": created_at.to_rfc3339()
+            }));
+        }
+        Ok(out)
+    }
+
+    pub(crate) fn list_plantations(&mut self) -> Result<Vec<serde_json::Value>, String> {
+        let rows = self.client.query(
+            "SELECT id, name, crop_type, created_at FROM plantations ORDER BY id",
+            &[],
+        ).map_err(|e| format!("list_plantations error: {}", e))?;
+        let mut out = Vec::new();
+        for r in rows {
+            let id: i32 = r.get("id");
+            let name: String = r.get("name");
+            let crop_type: String = r.get("crop_type");
+            let created_at: chrono::DateTime<chrono::Utc> = r.get("created_at");
+            out.push(serde_json::json!({
+                "id": id,
+                "name": name,
+                "crop_type": crop_type,
+                "created_at": created_at.to_rfc3339()
+            }));
+        }
+        Ok(out)
     }
 
     pub(crate) fn get_max_tree_seq(&mut self, prefix: &str) -> Result<i64, String> {

--- a/cloud/src/http_server.rs
+++ b/cloud/src/http_server.rs
@@ -646,6 +646,12 @@ fn handle_api(
                 r#"{"status":"error","message":"deprecated endpoint: /api/fields"}"#,
             );
         }
+        (Method::Get, "/api/v1/plantations") => {
+            crate::tree::handle_list_plantations(request, db);
+        }
+        (Method::Get, "/api/v1/trees") => {
+            crate::tree::handle_list_trees(request, query, db);
+        }
         (method, p) if p.starts_with("/api/v1/uav/") || p.starts_with("/api/v1/trees/") => {
             if method == Method::Post && p == "/api/v1/uav/missions" {
                 crate::uav::handle_missions_post(request, db);
@@ -667,6 +673,12 @@ fn handle_api(
             } else if method == Method::Post && p.ends_with("/reject") {
                 let det_id = extract_path_segment(p, "/detections/").unwrap_or_default();
                 crate::uav::handle_reject_detection(request, &det_id, db);
+            } else if method == Method::Get && p.starts_with("/api/v1/trees/") && p.ends_with("/timeline") {
+                let tree_code = extract_path_segment(p, "/trees/").unwrap_or_default();
+                crate::tree::handle_get_timeline(request, &tree_code, db);
+            } else if method == Method::Put && p.starts_with("/api/v1/trees/") && p.ends_with("/status") {
+                let tree_code = extract_path_segment(p, "/trees/").unwrap_or_default();
+                crate::tree::handle_update_status(request, &tree_code, db);
             } else if method == Method::Get && p.starts_with("/api/v1/trees/") {
                 let tree_code = extract_path_segment(p, "/trees/").unwrap_or_default();
                 crate::tree::handle_get_tree(request, &tree_code, db);

--- a/cloud/src/tree.rs
+++ b/cloud/src/tree.rs
@@ -9,6 +9,8 @@ fn respond_json(request: Request, status: u16, body: &str) {
     let _ = request.respond(response);
 }
 
+const ALLOWED_TREE_STATUSES: &[&str] = &["active", "dead", "removed", "replanted"];
+
 pub(crate) fn handle_get_tree(request: Request, tree_code: &str, db: Arc<Mutex<DbManager>>) {
     let result = db.lock()
         .map_err(|_| "db lock failed".to_string())
@@ -17,6 +19,110 @@ pub(crate) fn handle_get_tree(request: Request, tree_code: &str, db: Arc<Mutex<D
     match result {
         Ok(Some(json)) => respond_json(request, 200, &format!(r#"{{"status":"ok","tree":{}}}"#, json.to_string())),
         Ok(None) => respond_json(request, 404, r#"{"status":"error","message":"tree not found"}"#),
-        Err(e) => respond_json(request, 500, &format!(r#"{{"status":"error","message":"{e}"}}"#)),
+        Err(e) => respond_json(request, 500, &format!(r#"{{"status":"error","message":"{}"}}"#, e)),
     }
+}
+
+pub(crate) fn handle_get_timeline(request: Request, tree_code: &str, db: Arc<Mutex<DbManager>>) {
+    let result = db.lock()
+        .map_err(|_| "db lock failed".to_string())
+        .and_then(|mut g| g.get_tree_timeline(tree_code));
+
+    match result {
+        Ok(list) => respond_json(request, 200, &format!(
+            r#"{{"status":"ok","timeline":{}}}"#,
+            serde_json::to_string(&list).unwrap_or_else(|_| "[]".to_string())
+        )),
+        Err(e) => respond_json(request, 500, &format!(r#"{{"status":"error","message":"{}"}}"#, e)),
+    }
+}
+
+pub(crate) fn handle_update_status(mut request: Request, tree_code: &str, db: Arc<Mutex<DbManager>>) {
+    let mut body = Vec::new();
+    let _ = request.as_reader().read_to_end(&mut body);
+    let parsed: serde_json::Value = serde_json::from_slice(&body).unwrap_or_default();
+    let status_str = parsed["status"].as_str().unwrap_or("");
+
+    if !ALLOWED_TREE_STATUSES.contains(&status_str) {
+        respond_json(request, 400, &format!(
+            r#"{{"status":"error","message":"invalid status '{}'. allowed: {:?}"}}"#,
+            status_str, ALLOWED_TREE_STATUSES
+        ));
+        return;
+    }
+
+    let result = db.lock()
+        .map_err(|_| "db lock failed".to_string())
+        .and_then(|mut g| g.update_tree_status(tree_code, status_str));
+
+    match result {
+        Ok(()) => respond_json(request, 200, r#"{"status":"ok"}"#),
+        Err(e) if e.contains("tree not found") => respond_json(request, 404, r#"{"status":"error","message":"tree not found"}"#),
+        Err(e) => respond_json(request, 500, &format!(r#"{{"status":"error","message":"{}"}}"#, e)),
+    }
+}
+
+pub(crate) fn handle_list_trees(request: Request, query: &str, db: Arc<Mutex<DbManager>>) {
+    let params = parse_query_params(query);
+    let plantation_id: i32 = params.get("plantation_id")
+        .and_then(|v| v.parse().ok())
+        .unwrap_or(0);
+    let page: i64 = params.get("page")
+        .and_then(|v| v.parse().ok())
+        .unwrap_or(1)
+        .max(1);
+    let limit: i64 = params.get("limit")
+        .and_then(|v| v.parse().ok())
+        .unwrap_or(20)
+        .min(100)
+        .max(1);
+    let offset = (page - 1) * limit;
+
+    if plantation_id <= 0 {
+        respond_json(request, 400, r#"{"status":"error","message":"plantation_id is required"}"#);
+        return;
+    }
+
+    let result = db.lock()
+        .map_err(|_| "db lock failed".to_string())
+        .and_then(|mut g| {
+            let total = g.count_trees_by_plantation(plantation_id)?;
+            let trees = g.list_trees_by_plantation(plantation_id, limit, offset)?;
+            Ok((trees, total))
+        });
+
+    match result {
+        Ok((trees, total)) => {
+            let trees_json = serde_json::to_string(&trees).unwrap_or_else(|_| "[]".to_string());
+            respond_json(request, 200, &format!(
+                r#"{{"status":"ok","trees":{},"page":{},"limit":{},"total":{}}}"#,
+                trees_json, page, limit, total
+            ));
+        }
+        Err(e) => respond_json(request, 500, &format!(r#"{{"status":"error","message":"{}"}}"#, e)),
+    }
+}
+
+pub(crate) fn handle_list_plantations(request: Request, db: Arc<Mutex<DbManager>>) {
+    let result = db.lock()
+        .map_err(|_| "db lock failed".to_string())
+        .and_then(|mut g| g.list_plantations());
+
+    match result {
+        Ok(list) => respond_json(request, 200, &format!(
+            r#"{{"status":"ok","plantations":{}}}"#,
+            serde_json::to_string(&list).unwrap_or_else(|_| "[]".to_string())
+        )),
+        Err(e) => respond_json(request, 500, &format!(r#"{{"status":"error","message":"{}"}}"#, e)),
+    }
+}
+
+fn parse_query_params(query: &str) -> std::collections::HashMap<String, String> {
+    let mut map = std::collections::HashMap::new();
+    for pair in query.split('&') {
+        if let Some((k, v)) = pair.split_once('=') {
+            map.insert(k.to_string(), v.to_string());
+        }
+    }
+    map
 }

--- a/frontend/oil_palm/app.js
+++ b/frontend/oil_palm/app.js
@@ -87,7 +87,7 @@ document.addEventListener('DOMContentLoaded', () => {
             
             const treeDiv = document.createElement('div');
             treeDiv.className = 'tree-item';
-            treeDiv.innerHTML = `<span>🌳 Tree: <strong>${data.tree_code}</strong></span>`;
+            treeDiv.innerHTML = `<span>🌳 Tree: <a href="tree_profile.html?code=${data.tree_code}" style="color:#60a5fa;text-decoration:none;font-weight:700;">${data.tree_code}</a></span>`;
             treeList.appendChild(treeDiv);
         } catch (e) {
             alert('Confirm failed');

--- a/frontend/oil_palm/index.html
+++ b/frontend/oil_palm/index.html
@@ -13,7 +13,8 @@
     <div class="container">
         <header>
             <h1>Oil Palm UAV Mapping & Review</h1>
-            <a href="/" class="back-link">Back to Portal</a>
+            <a href="tree_list.html" class="back-link">Tree Registry</a>
+            <a href="/" class="back-link" style="margin-left:12px;">Back to Portal</a>
         </header>
 
         <main>

--- a/frontend/oil_palm/tree_list.html
+++ b/frontend/oil_palm/tree_list.html
@@ -1,0 +1,130 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Tree Registry</title>
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;600;800&family=Outfit:wght@400;700&display=swap" rel="stylesheet">
+    <link rel="stylesheet" href="styles.css">
+    <style>
+        .toolbar {
+            display: flex;
+            align-items: center;
+            gap: 1rem;
+            margin-bottom: 1.2rem;
+            flex-wrap: wrap;
+        }
+        .toolbar select {
+            padding: 8px 12px;
+            border-radius: 8px;
+            background: rgba(255,255,255,0.06);
+            border: 1px solid rgba(255,255,255,0.1);
+            color: #e0e0e0;
+            font-size: 0.9rem;
+        }
+        .toolbar .total-badge {
+            margin-left: auto;
+            font-size: 0.85rem;
+            color: rgba(255,255,255,0.5);
+        }
+        .tree-table {
+            width: 100%;
+            border-collapse: collapse;
+            font-size: 0.9rem;
+        }
+        .tree-table th {
+            text-align: left;
+            padding: 10px 12px;
+            color: rgba(255,255,255,0.5);
+            font-size: 0.8rem;
+            text-transform: uppercase;
+            letter-spacing: 0.05em;
+            border-bottom: 1px solid rgba(255,255,255,0.08);
+        }
+        .tree-table td {
+            padding: 10px 12px;
+            border-bottom: 1px solid rgba(255,255,255,0.04);
+            color: #d1d5db;
+        }
+        .tree-table tr:hover td {
+            background: rgba(255,255,255,0.03);
+        }
+        .tree-table a {
+            color: #60a5fa;
+            text-decoration: none;
+            font-weight: 500;
+        }
+        .tree-table a:hover { text-decoration: underline; }
+        .badge {
+            display: inline-block;
+            padding: 2px 8px;
+            border-radius: 999px;
+            font-size: 0.75rem;
+            font-weight: 600;
+        }
+        .badge-active { background: rgba(34,197,94,0.15); color: #22c55e; }
+        .badge-dead { background: rgba(239,68,68,0.15); color: #ef4444; }
+        .badge-removed { background: rgba(156,163,175,0.15); color: #9ca3af; }
+        .badge-replanted { background: rgba(59,130,246,0.15); color: #3b82f6; }
+        .pagination {
+            display: flex;
+            align-items: center;
+            justify-content: center;
+            gap: 1rem;
+            margin-top: 1.2rem;
+            color: rgba(255,255,255,0.5);
+            font-size: 0.9rem;
+        }
+        .pagination button {
+            padding: 6px 16px;
+            border: 1px solid rgba(255,255,255,0.1);
+            border-radius: 8px;
+            background: rgba(255,255,255,0.05);
+            color: #d1d5db;
+            cursor: pointer;
+            transition: all 0.2s;
+        }
+        .pagination button:hover:not(:disabled) { background: rgba(255,255,255,0.1); }
+        .pagination button:disabled { opacity: 0.3; cursor: default; }
+        .empty-state {
+            text-align: center;
+            padding: 3rem;
+            color: rgba(255,255,255,0.35);
+            font-style: italic;
+        }
+    </style>
+</head>
+<body>
+    <div class="container">
+        <header>
+            <h1>🌴 Tree Registry</h1>
+            <div>
+                <a href="index.html" class="back-link">UAV Review</a>
+                <a href="/" class="back-link" style="margin-left:12px;">Portal</a>
+            </div>
+        </header>
+        <main>
+            <section class="panel">
+                <div class="toolbar">
+                    <label for="plantation-select" style="color:rgba(255,255,255,0.6);">Plantation:</label>
+                    <select id="plantation-select">
+                        <option value="">Loading...</option>
+                    </select>
+                    <span class="total-badge" id="total-badge"></span>
+                </div>
+                <div id="table-container">
+                    <div class="empty-state">Select a plantation to view trees</div>
+                </div>
+                <div class="pagination" id="pagination" style="display:none;">
+                    <button id="btn-prev" disabled>&laquo; Prev</button>
+                    <span id="page-info">Page 1</span>
+                    <button id="btn-next">&raquo; Next</button>
+                </div>
+            </section>
+        </main>
+    </div>
+    <script src="tree_list.js"></script>
+</body>
+</html>

--- a/frontend/oil_palm/tree_list.js
+++ b/frontend/oil_palm/tree_list.js
@@ -1,0 +1,118 @@
+document.addEventListener('DOMContentLoaded', async () => {
+    const select = document.getElementById('plantation-select');
+    const tableContainer = document.getElementById('table-container');
+    const totalBadge = document.getElementById('total-badge');
+    const pagination = document.getElementById('pagination');
+    const btnPrev = document.getElementById('btn-prev');
+    const btnNext = document.getElementById('btn-next');
+    const pageInfo = document.getElementById('page-info');
+
+    let currentPage = 1;
+    const limit = 20;
+    let totalTrees = 0;
+
+    // Load plantations
+    try {
+        const res = await fetch('/api/v1/plantations');
+        const data = await res.json();
+        const plantations = data.plantations || [];
+        select.innerHTML = '<option value="">-- Select --</option>';
+        plantations.forEach(p => {
+            const opt = document.createElement('option');
+            opt.value = p.id;
+            opt.textContent = `${p.name} (${p.crop_type})`;
+            select.appendChild(opt);
+        });
+        // Auto-select first if only one
+        if (plantations.length === 1) {
+            select.value = plantations[0].id;
+            loadTrees();
+        }
+    } catch (e) {
+        select.innerHTML = '<option value="">Failed to load</option>';
+    }
+
+    select.addEventListener('change', () => {
+        currentPage = 1;
+        loadTrees();
+    });
+
+    btnPrev.addEventListener('click', () => {
+        if (currentPage > 1) {
+            currentPage--;
+            loadTrees();
+        }
+    });
+
+    btnNext.addEventListener('click', () => {
+        const totalPages = Math.ceil(totalTrees / limit);
+        if (currentPage < totalPages) {
+            currentPage++;
+            loadTrees();
+        }
+    });
+
+    async function loadTrees() {
+        const pid = select.value;
+        if (!pid) {
+            tableContainer.innerHTML = '<div class="empty-state">Select a plantation to view trees</div>';
+            pagination.style.display = 'none';
+            totalBadge.textContent = '';
+            return;
+        }
+
+        try {
+            const res = await fetch(`/api/v1/trees?plantation_id=${pid}&page=${currentPage}&limit=${limit}`);
+            const data = await res.json();
+            const trees = data.trees || [];
+            totalTrees = data.total || 0;
+
+            totalBadge.textContent = `Total: ${totalTrees} trees`;
+
+            if (trees.length === 0) {
+                tableContainer.innerHTML = '<div class="empty-state">No trees registered in this plantation</div>';
+                pagination.style.display = 'none';
+                return;
+            }
+
+            const totalPages = Math.ceil(totalTrees / limit);
+            renderTable(trees);
+            updatePagination(totalPages);
+        } catch (e) {
+            tableContainer.innerHTML = `<div class="empty-state">Error: ${e.message}</div>`;
+        }
+    }
+
+    function renderTable(trees) {
+        let html = `<table class="tree-table">
+            <thead><tr>
+                <th>Code</th><th>Species</th><th>Status</th><th>Coordinate</th><th>Action</th>
+            </tr></thead><tbody>`;
+        trees.forEach(t => {
+            const statusClass = `badge-${t.current_status}`;
+            const coord = (t.coordinate_x != null && t.coordinate_y != null)
+                ? `(${t.coordinate_x.toFixed(1)}, ${t.coordinate_y.toFixed(1)})`
+                : '-';
+            html += `<tr>
+                <td><a href="tree_profile.html?code=${t.tree_code}">${t.tree_code}</a></td>
+                <td>${t.species}</td>
+                <td><span class="badge ${statusClass}">${t.current_status}</span></td>
+                <td>${coord}</td>
+                <td><a href="tree_profile.html?code=${t.tree_code}">View</a></td>
+            </tr>`;
+        });
+        html += '</tbody></table>';
+        tableContainer.innerHTML = html;
+    }
+
+    function updatePagination(totalPages) {
+        if (totalPages <= 1) {
+            pagination.style.display = 'none';
+            return;
+        }
+        pagination.style.display = 'flex';
+        pageInfo.textContent = `Page ${currentPage} of ${totalPages}`;
+        btnPrev.disabled = currentPage <= 1;
+        btnNext.disabled = currentPage >= totalPages;
+    }
+});

--- a/frontend/oil_palm/tree_profile.html
+++ b/frontend/oil_palm/tree_profile.html
@@ -1,0 +1,124 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Tree Profile</title>
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;600;800&family=Outfit:wght@400;700&display=swap" rel="stylesheet">
+    <link rel="stylesheet" href="styles.css">
+    <style>
+        .profile-grid {
+            display: grid;
+            grid-template-columns: 1fr 1fr;
+            gap: 1.2rem;
+        }
+        @media (max-width: 640px) {
+            .profile-grid { grid-template-columns: 1fr; }
+        }
+        .info-card {
+            background: rgba(255,255,255,0.04);
+            border: 1px solid rgba(255,255,255,0.08);
+            border-radius: 12px;
+            padding: 1.2rem;
+        }
+        .info-card h3 {
+            font-size: 0.85rem;
+            color: rgba(255,255,255,0.5);
+            text-transform: uppercase;
+            letter-spacing: 0.05em;
+            margin-bottom: 0.8rem;
+        }
+        .info-row {
+            display: flex;
+            justify-content: space-between;
+            padding: 0.4rem 0;
+            border-bottom: 1px solid rgba(255,255,255,0.04);
+            font-size: 0.92rem;
+        }
+        .info-row:last-child { border-bottom: none; }
+        .info-label { color: rgba(255,255,255,0.5); }
+        .info-value { color: #e0e0e0; font-weight: 500; }
+        .badge {
+            display: inline-block;
+            padding: 2px 10px;
+            border-radius: 999px;
+            font-size: 0.8rem;
+            font-weight: 600;
+        }
+        .badge-active { background: rgba(34,197,94,0.15); color: #22c55e; }
+        .badge-dead { background: rgba(239,68,68,0.15); color: #ef4444; }
+        .badge-removed { background: rgba(156,163,175,0.15); color: #9ca3af; }
+        .badge-replanted { background: rgba(59,130,246,0.15); color: #3b82f6; }
+        .timeline-empty {
+            text-align: center;
+            padding: 2rem;
+            color: rgba(255,255,255,0.35);
+            font-style: italic;
+        }
+        .timeline-item {
+            background: rgba(255,255,255,0.03);
+            border-left: 3px solid rgba(59,130,246,0.5);
+            padding: 0.8rem 1rem;
+            margin-bottom: 0.6rem;
+            border-radius: 0 8px 8px 0;
+        }
+        .action-bar {
+            display: flex;
+            gap: 0.8rem;
+            margin-top: 1rem;
+            flex-wrap: wrap;
+        }
+        .btn-status {
+            padding: 8px 16px;
+            border: 1px solid rgba(255,255,255,0.12);
+            border-radius: 8px;
+            background: rgba(255,255,255,0.05);
+            color: #d1d5db;
+            cursor: pointer;
+            font-size: 0.85rem;
+            transition: all 0.2s;
+        }
+        .btn-status:hover { background: rgba(255,255,255,0.1); }
+        .btn-status.danger { border-color: rgba(239,68,68,0.3); color: #ef4444; }
+        .btn-status.danger:hover { background: rgba(239,68,68,0.1); }
+    </style>
+</head>
+<body>
+    <div class="container">
+        <header>
+            <h1 id="profile-title">Tree Profile</h1>
+            <div>
+                <a href="tree_list.html" class="back-link">Tree Registry</a>
+                <a href="index.html" class="back-link" style="margin-left:12px;">UAV Review</a>
+                <a href="/" class="back-link" style="margin-left:12px;">Portal</a>
+            </div>
+        </header>
+        <main>
+            <div id="loading" class="status-box">Loading tree data...</div>
+            <div id="profile-content" style="display:none;">
+                <div class="profile-grid">
+                    <div class="info-card">
+                        <h3>Basic Info</h3>
+                        <div id="basic-info"></div>
+                    </div>
+                    <div class="info-card">
+                        <h3>Location</h3>
+                        <div id="location-info"></div>
+                    </div>
+                </div>
+                <section class="panel" style="margin-top:1.5rem;">
+                    <h2>Timeline / Coordinate History</h2>
+                    <div id="timeline-content"></div>
+                </section>
+                <section class="panel">
+                    <h2>Actions</h2>
+                    <div class="action-bar" id="action-bar"></div>
+                </section>
+            </div>
+        </main>
+    </div>
+    <script src="tree_profile.js"></script>
+</body>
+</html>

--- a/frontend/oil_palm/tree_profile.js
+++ b/frontend/oil_palm/tree_profile.js
@@ -1,0 +1,125 @@
+document.addEventListener('DOMContentLoaded', async () => {
+    const params = new URLSearchParams(window.location.search);
+    const code = params.get('code');
+    const loading = document.getElementById('loading');
+    const content = document.getElementById('profile-content');
+
+    if (!code) {
+        loading.textContent = 'Error: No tree code provided. Use ?code=OP-XXXXXX';
+        return;
+    }
+
+    document.getElementById('profile-title').textContent = `\u{1F334} Tree Profile: ${code}`;
+
+    try {
+        const res = await fetch(`/api/v1/trees/${code}`);
+        if (!res.ok) {
+            loading.textContent = `Error: Tree "${code}" not found (HTTP ${res.status})`;
+            return;
+        }
+        const data = await res.json();
+        const tree = data.tree;
+
+        renderBasicInfo(tree);
+        renderLocationInfo(tree);
+        renderActions(tree, code);
+
+        loading.style.display = 'none';
+        content.style.display = 'block';
+    } catch (e) {
+        loading.textContent = 'Error loading tree: ' + e.message;
+        return;
+    }
+
+    try {
+        const tlRes = await fetch(`/api/v1/trees/${code}/timeline`);
+        const tlData = await tlRes.json();
+        renderTimeline(tlData.timeline || []);
+    } catch (e) {
+        document.getElementById('timeline-content').innerHTML =
+            '<div class="timeline-empty">Failed to load timeline</div>';
+    }
+});
+
+function renderBasicInfo(tree) {
+    const statusClass = `badge-${tree.current_status}`;
+    document.getElementById('basic-info').innerHTML = `
+        <div class="info-row"><span class="info-label">Tree Code</span><span class="info-value">${tree.tree_code}</span></div>
+        <div class="info-row"><span class="info-label">Species</span><span class="info-value">${tree.species}</span></div>
+        <div class="info-row"><span class="info-label">Status</span><span class="info-value"><span class="badge ${statusClass}">${tree.current_status}</span></span></div>
+        <div class="info-row"><span class="info-label">Barcode</span><span class="info-value">${tree.barcode_value || '-'}</span></div>
+        <div class="info-row"><span class="info-label">Verified</span><span class="info-value">${tree.manual_verified ? '\u2705 Yes' : '\u274C No'}</span></div>
+        <div class="info-row"><span class="info-label">Plantation</span><span class="info-value">${tree.plantation_name || '-'}</span></div>
+        <div class="info-row"><span class="info-label">Created</span><span class="info-value">${formatDate(tree.created_at)}</span></div>
+    `;
+}
+
+function renderLocationInfo(tree) {
+    document.getElementById('location-info').innerHTML = `
+        <div class="info-row"><span class="info-label">Coordinate X</span><span class="info-value">${tree.coordinate_x ?? '-'}</span></div>
+        <div class="info-row"><span class="info-label">Coordinate Y</span><span class="info-value">${tree.coordinate_y ?? '-'}</span></div>
+        <div class="info-row"><span class="info-label">Crown Center X</span><span class="info-value">${tree.crown_center_x ?? '-'}</span></div>
+        <div class="info-row"><span class="info-label">Crown Center Y</span><span class="info-value">${tree.crown_center_y ?? '-'}</span></div>
+        <div class="info-row"><span class="info-label">Source Ortho ID</span><span class="info-value">${tree.source_orthomosaic_id ?? '-'}</span></div>
+        <div class="info-row"><span class="info-label">Block</span><span class="info-value">${tree.block_id || '-'}</span></div>
+    `;
+}
+
+function renderTimeline(timeline) {
+    const el = document.getElementById('timeline-content');
+    if (timeline.length === 0) {
+        el.innerHTML = '<div class="timeline-empty">\u{1F4ED} No history records yet. Timeline will be populated when future UAV missions match this tree.</div>';
+        return;
+    }
+    el.innerHTML = timeline.map(t => `
+        <div class="timeline-item">
+            <strong>${t.mission_name}</strong>
+            <span style="color:rgba(255,255,255,0.4); margin-left:8px;">${formatDate(t.mission_date || t.created_at)}</span>
+            <div style="margin-top:4px; font-size:0.88rem; color:#9ca3af;">
+                Detected: (${t.detected_x?.toFixed(2) ?? '-'}, ${t.detected_y?.toFixed(2) ?? '-'})
+                &bull; Shift: ${t.center_shift?.toFixed(3) ?? '-'}
+                &bull; Confidence: ${t.match_confidence?.toFixed(2) ?? '-'}
+            </div>
+        </div>
+    `).join('');
+}
+
+function renderActions(tree, code) {
+    const bar = document.getElementById('action-bar');
+    const statuses = ['active', 'dead', 'removed', 'replanted'];
+    statuses.forEach(s => {
+        if (s === tree.current_status) return;
+        const btn = document.createElement('button');
+        btn.className = 'btn-status' + (s === 'dead' || s === 'removed' ? ' danger' : '');
+        btn.textContent = `Mark as ${s}`;
+        btn.addEventListener('click', async () => {
+            if (!confirm(`Change status to "${s}"?`)) return;
+            try {
+                const res = await fetch(`/api/v1/trees/${code}/status`, {
+                    method: 'PUT',
+                    headers: { 'Content-Type': 'application/json' },
+                    body: JSON.stringify({ status: s })
+                });
+                if (res.ok) {
+                    window.location.reload();
+                } else {
+                    const err = await res.json();
+                    alert('Failed: ' + (err.message || 'unknown error'));
+                }
+            } catch (e) {
+                alert('Error: ' + e.message);
+            }
+        });
+        bar.appendChild(btn);
+    });
+}
+
+function formatDate(iso) {
+    if (!iso) return '-';
+    try {
+        return new Date(iso).toLocaleDateString('en-US', {
+            year: 'numeric', month: 'short', day: 'numeric',
+            hour: '2-digit', minute: '2-digit'
+        });
+    } catch { return iso; }
+}

--- a/tests/test_uav_api.py
+++ b/tests/test_uav_api.py
@@ -75,3 +75,91 @@ def test_missing_detection():
     # 9. Non-existent detection
     res = requests.post(f"{BASE_URL}/api/v1/uav/detections/999999/confirm")
     assert res.status_code == 500
+
+def test_list_plantations():
+    """Verify plantations endpoint returns a list."""
+    res = requests.get(f"{BASE_URL}/api/v1/plantations")
+    assert res.status_code == 200
+    data = res.json()
+    assert data["status"] == "ok"
+    assert isinstance(data["plantations"], list)
+    assert len(data["plantations"]) >= 1
+
+def test_tree_detail_fields():
+    """Verify tree detail returns enhanced fields after confirm."""
+    # First, create a tree through the confirm flow
+    res = requests.post(f"{BASE_URL}/api/v1/uav/missions", json={"plantation_id": 0, "mission_name": "detail_test"})
+    mission_id = res.json()["mission_id"]
+    res = requests.post(f"{BASE_URL}/api/v1/uav/missions/{mission_id}/orthomosaic")
+    ortho_id = res.json()["orthomosaic_id"]
+    requests.post(f"{BASE_URL}/api/v1/uav/orthomosaics/{ortho_id}/detections/mock")
+    res = requests.get(f"{BASE_URL}/api/v1/uav/orthomosaics/{ortho_id}/detections")
+    det_id = res.json()["detections"][0]["id"]
+    res = requests.post(f"{BASE_URL}/api/v1/uav/detections/{det_id}/confirm")
+    tree_code = res.json()["tree_code"]
+
+    # Verify enhanced detail
+    res = requests.get(f"{BASE_URL}/api/v1/trees/{tree_code}")
+    assert res.status_code == 200
+    tree = res.json()["tree"]
+    assert tree["tree_code"] == tree_code
+    assert tree["species"] == "oil_palm"
+    assert "barcode_value" in tree
+    assert "manual_verified" in tree
+    assert "plantation_name" in tree
+    assert "created_at" in tree
+    assert "coordinate_x" in tree
+
+def test_list_trees_with_pagination():
+    """Verify tree list returns total count for pagination."""
+    # Get a plantation ID
+    res = requests.get(f"{BASE_URL}/api/v1/plantations")
+    pid = res.json()["plantations"][0]["id"]
+
+    res = requests.get(f"{BASE_URL}/api/v1/trees?plantation_id={pid}&page=1&limit=10")
+    assert res.status_code == 200
+    data = res.json()
+    assert data["status"] == "ok"
+    assert isinstance(data["trees"], list)
+    assert "total" in data
+    assert data["total"] >= 0
+    assert data["page"] == 1
+    assert data["limit"] == 10
+
+def test_tree_timeline_empty():
+    """Verify timeline returns 200 with empty list for new trees."""
+    # Get a tree code from earlier tests
+    res = requests.get(f"{BASE_URL}/api/v1/plantations")
+    pid = res.json()["plantations"][0]["id"]
+    res = requests.get(f"{BASE_URL}/api/v1/trees?plantation_id={pid}&page=1&limit=1")
+    trees = res.json()["trees"]
+    if len(trees) == 0:
+        return  # skip if no trees
+    code = trees[0]["tree_code"]
+
+    res = requests.get(f"{BASE_URL}/api/v1/trees/{code}/timeline")
+    assert res.status_code == 200
+    data = res.json()
+    assert data["status"] == "ok"
+    assert isinstance(data["timeline"], list)
+
+def test_update_tree_status_validation():
+    """Verify status update rejects invalid values and accepts valid ones."""
+    # Get a tree
+    res = requests.get(f"{BASE_URL}/api/v1/plantations")
+    pid = res.json()["plantations"][0]["id"]
+    res = requests.get(f"{BASE_URL}/api/v1/trees?plantation_id={pid}&page=1&limit=1")
+    trees = res.json()["trees"]
+    if len(trees) == 0:
+        return
+    code = trees[0]["tree_code"]
+
+    # Invalid status should return 400
+    res = requests.put(f"{BASE_URL}/api/v1/trees/{code}/status",
+                       json={"status": "happy"})
+    assert res.status_code == 400
+
+    # Valid status should return 200
+    res = requests.put(f"{BASE_URL}/api/v1/trees/{code}/status",
+                       json={"status": "active"})
+    assert res.status_code == 200


### PR DESCRIPTION
…ee APIs

- Enhance get_tree_by_code: JOIN plantations + orthomosaics, return full detail
- Add list_trees_by_plantation with LIMIT/OFFSET pagination
- Add count_trees_by_plantation for total count
- Add update_tree_status with allowed-status enum validation (400 for invalid)
- Add get_tree_timeline for coordinate history
- Add list_plantations for dropdown selection
- New routes: GET /api/v1/trees, GET /api/v1/plantations, GET /api/v1/trees/{code}/timeline, PUT /api/v1/trees/{code}/status
- New frontend: tree_profile.html/js, tree_list.html/js
- Update app.js: tree codes become clickable links to Tree Profile
- Update index.html: add Tree Registry navigation link
- Expand tests: plantation list, tree detail fields, pagination total, empty timeline, status validation

## 背景 / Background
在 Phase 1 完成了 UAV 坐标底座和树木初步登记功能后，用户确认产生的树木编号（如 `OP-000001`）处于“孤立”状态，缺乏可查看详情的档案页、可管理的列表页以及状态更新能力。

本 PR 旨在通过补全 Tree Profile 和 Tree Registry 相关功能，将 Phase 1 登记的静态数据转化为可交互、可追踪的资产档案，实现“确认→查看→管理”的闭环。

## 变更摘要 / Change Summary
1.  **数据库方法增强**：重构 `get_tree_by_code`，通过 JOIN 关联果园和正射图信息返回完整档案；新增树木列表（带分页）、总数统计、状态更新及坐标历史查询方法。
2.  **API 健壮性提升**：新增树木状态更新接口并引入 **Enum 式合法性校验**（active/dead/removed/replanted），防止非预期字符串进入数据库。
3.  **分页响应规范化**：树木列表接口统一返回 `total` 总数，为前端分页器提供标准数据支撑。
4.  **前端新增档案页**：创建 `tree_profile.html/js`，展示单树的详细信息卡片、坐标属性以及历史检测时间线（支持空历史优雅显示）。
5.  **前端新增注册表**：创建 `tree_list.html/js`，提供基于果园筛选的树木列表展示与分页导航功能。
6.  **链路打通**：将 UAV Review 确认后生成的树号改为跳转链接，并在主界面新增 "Tree Registry" 导航入口。

## 变更类型 / Type of Change
- [ ] 🐛 Bug 修复 (Bug fix)
- [x] ✨ 新功能 (New feature)
- [ ] 🔧 重构 (Refactor)
- [ ] 📝 文档更新 (Documentation update)
- [ ] 🔒 安全修复 (Security fix)
- [ ] 其他 (Other): ___

## 影响范围 / Impact Scope
- [ ] gateway
- [x] cloud
- [ ] deploy/script
- [ ] docs

## 测试说明 / Testing

### 本地验证命令 / Local Verification Commands
```bash
# 验证 Rust 后端编译与单元测试
cd cloud
cargo check
cargo test

# 验证 API 功能（需启动 cloud 服务后）
python -m pytest tests/test_uav_api.py -v
```

### 结果摘要 / Result Summary
- [x] 已在本地通过测试 / Tests pass locally (24 unit tests passed)
- [x] 关键路径已手工验证 / Critical path manually verified (确认树木 -> 点击编号跳转 Profile -> 更新状态)

## 配置与部署变更 / Config & Deploy Changes
- [x] 无 / None

## 风险与回滚 / Risks & Rollback
- 风险 / Risks: 无数据库迁移变更，风险极低。主要为新增 API 路由，不影响旧有 Rice 接口。
- 回滚 / Rollback: `git checkout dev` 即可。

## 检查清单 / Checklist
- [x] 代码符合项目风格规范 / Code follows project style guidelines
- [x] 已完成自我审查 / Self-review completed
- [x] 相关文档已更新（如有需要）/ Documentation updated (if needed)
- [x] 无新增安全漏洞 / No new security vulnerabilities introduced
- [x] 无无关改动进入 PR / No unrelated changes included

## 关联 Issue / Related Issue
#65 