### PR TITLE
fix(tree-profile): return valid JSON body for invalid tree status

### DIFF
--- a/cloud/src/tree.rs
+++ b/cloud/src/tree.rs
@@ -44,10 +44,12 @@ pub(crate) fn handle_update_status(mut request: Request, tree_code: &str, db: Ar
     let status_str = parsed["status"].as_str().unwrap_or("");
 
     if !ALLOWED_TREE_STATUSES.contains(&status_str) {
-        respond_json(request, 400, &format!(
-            r#"{{"status":"error","message":"invalid status '{}'. allowed: {:?}"}}"#,
-            status_str, ALLOWED_TREE_STATUSES
-        ));
+        let body = serde_json::json!({
+            "status": "error",
+            "message": format!("invalid status '{}'", status_str),
+            "allowed_statuses": ALLOWED_TREE_STATUSES,
+        });
+        respond_json(request, 400, &body.to_string());
         return;
     }
 


### PR DESCRIPTION
### Motivation
- A reviewer noted that the 400 response for invalid tree status used `{:?}` inside a JSON string which could emit quoted Rust debug formatting and produce malformed JSON, breaking clients that call `.json()` on non-2xx responses.

### Description
- Replaced manual string formatting with `serde_json::json!` in `cloud/src/tree.rs` so the invalid-status 400 response serializes to valid JSON and added a structured `allowed_statuses` array while preserving `status` and `message` keys.

### Testing
- Attempted `cd cloud && cargo test -q` in this environment but the run failed due to a crates.io download/network 403 so no tests executed here; no test code was changed and the fix is a small, non-breaking response-format change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f3322708d8832181607d9340b255ee)