### PR TITLE
feat: add OpenClaw read-only tool APIs

### DIFF
--- a/cloud/README.md
+++ b/cloud/README.md
@@ -190,6 +190,21 @@ CHAT_ADAPTER_WORKERS=4 CHAT_ADAPTER_TIMEOUT_SEC=90 \
 python3 scripts/openclaw_chat_adapter.py --host 127.0.0.1 --port 3000
 ```
 
+## OpenClaw read-only tool API
+
+Sprint F exposes bounded, read-only agricultural tool endpoints for OpenClaw:
+
+- `GET /api/v1/openclaw/tools/manifest`
+- `GET /api/v1/openclaw/tools/tree-profile?tree_code=OP-000001`
+- `GET /api/v1/openclaw/tools/tree-timeline?tree_code=OP-000001&limit=20`
+- `GET /api/v1/openclaw/tools/plantation-report?plantation_id=1&limit=50`
+- `GET /api/v1/openclaw/tools/missing-evidence?tree_code=OP-000001`
+- `GET /api/v1/openclaw/tools/patrol-report?plantation_id=1&limit=50`
+- `POST /api/v1/openclaw/tools/explain-prediction`
+
+These endpoints reuse existing structured data and do not write database state.
+See `doc/openclaw-tools.md` for the cloud-side OpenClaw registration template.
+
 ## Auth API (issue #64 baseline)
 
 Auth is session-token based for management/business APIs:

--- a/cloud/src/assessment.rs
+++ b/cloud/src/assessment.rs
@@ -59,7 +59,7 @@ pub(crate) fn handle_blocks_report(request: Request, plantation_id: &str, db: Ar
     }
 }
 
-fn build_tree_assessment_by_code(g: &mut DbManager, tree_code: &str) -> Result<Option<Value>, String> {
+pub(crate) fn build_tree_assessment_by_code(g: &mut DbManager, tree_code: &str) -> Result<Option<Value>, String> {
     let Some(tree) = g.get_tree_by_code(tree_code)? else {
         return Ok(None);
     };
@@ -69,7 +69,7 @@ fn build_tree_assessment_by_code(g: &mut DbManager, tree_code: &str) -> Result<O
     Ok(Some(build_tree_assessment(tree, images, history)))
 }
 
-fn build_plantation_dashboard(g: &mut DbManager, plantation_id: i32) -> Result<Value, String> {
+pub(crate) fn build_plantation_dashboard(g: &mut DbManager, plantation_id: i32) -> Result<Value, String> {
     let tree_refs = g.list_assessment_trees_by_plantation(plantation_id)?;
     let mut trees = Vec::new();
     let mut harvest_recommended = 0;
@@ -148,7 +148,7 @@ fn build_plantation_dashboard(g: &mut DbManager, plantation_id: i32) -> Result<V
     }))
 }
 
-fn build_blocks_report(g: &mut DbManager, plantation_id: i32) -> Result<Value, String> {
+pub(crate) fn build_blocks_report(g: &mut DbManager, plantation_id: i32) -> Result<Value, String> {
     let dashboard = build_plantation_dashboard(g, plantation_id)?;
     let mut blocks: BTreeMap<String, Value> = BTreeMap::new();
     for tree in dashboard["trees"].as_array().cloned().unwrap_or_default() {

--- a/cloud/src/http_server.rs
+++ b/cloud/src/http_server.rs
@@ -652,6 +652,9 @@ fn handle_api(
         (Method::Get, "/api/v1/trees") => {
             crate::tree::handle_list_trees(request, query, db);
         }
+        (method, p) if p.starts_with("/api/v1/openclaw/tools") => {
+            crate::openclaw_tools::handle_tool_request(request, method, p, query, db);
+        }
         (method, p) if p.starts_with("/api/v1/uav/") || p.starts_with("/api/v1/trees/") || p.starts_with("/api/v1/sessions/") || p.starts_with("/api/v1/plantations/") => {
             if method == Method::Post && p == "/api/v1/uav/missions" {
                 crate::uav::handle_missions_post(request, db);

--- a/cloud/src/main.rs
+++ b/cloud/src/main.rs
@@ -8,6 +8,7 @@ mod db;
 mod http_server;
 mod image_upload;
 mod model;
+mod openclaw_tools;
 mod payload;
 mod presence;
 mod registry;

--- a/cloud/src/openclaw_tools.rs
+++ b/cloud/src/openclaw_tools.rs
@@ -1,0 +1,401 @@
+use std::collections::HashMap;
+use std::sync::{Arc, Mutex};
+
+use chrono::Utc;
+use serde_json::{json, Value};
+use tiny_http::{Method, Request, Response};
+
+use crate::assessment::{build_blocks_report, build_plantation_dashboard, build_tree_assessment_by_code};
+use crate::db::DbManager;
+
+const MAX_TOOL_LIMIT: usize = 50;
+
+pub(crate) fn handle_tool_request(
+    mut request: Request,
+    method: Method,
+    path: &str,
+    query: &str,
+    db: Arc<Mutex<DbManager>>,
+) {
+    let result = match (method, path) {
+        (Method::Get, "/api/v1/openclaw/tools/manifest") => Ok(tool_manifest()),
+        (Method::Get, "/api/v1/openclaw/tools/tree-profile") => handle_tree_profile(query, db),
+        (Method::Get, "/api/v1/openclaw/tools/tree-timeline") => handle_tree_timeline(query, db),
+        (Method::Get, "/api/v1/openclaw/tools/plantation-report") => handle_plantation_report(query, db),
+        (Method::Get, "/api/v1/openclaw/tools/missing-evidence") => handle_missing_evidence(query, db),
+        (Method::Get, "/api/v1/openclaw/tools/patrol-report") => handle_patrol_report(query, db),
+        (Method::Post, "/api/v1/openclaw/tools/explain-prediction") => {
+            let mut body = Vec::new();
+            if let Err(err) = request.as_reader().read_to_end(&mut body) {
+                Err(tool_error(400, format!("failed to read request body: {err}")))
+            } else {
+                handle_explain_prediction(&body)
+            }
+        }
+        (Method::Get, "/api/v1/openclaw/tools/explain-prediction") => {
+            Err(tool_error(405, "use POST for explain-prediction".to_string()))
+        }
+        _ => Err(tool_error(404, "openclaw tool not found".to_string())),
+    };
+
+    match result {
+        Ok(payload) => respond_json(request, 200, &payload),
+        Err(err) => {
+            let status = err["http_status"].as_u64().unwrap_or(500) as u16;
+            respond_json(request, status, &err);
+        }
+    }
+}
+
+fn handle_tree_profile(query: &str, db: Arc<Mutex<DbManager>>) -> Result<Value, Value> {
+    let params = parse_query_params(query);
+    let tree_code = required_param(&params, "tree_code")?;
+    let limit = limit_param(&params, 10);
+
+    let result = db
+        .lock()
+        .map_err(|_| tool_error(500, "db lock failed".to_string()))
+        .and_then(|mut g| {
+            let Some(tree) = g.get_tree_by_code(&tree_code).map_err(internal_error)? else {
+                return Err(tool_error(404, "tree not found".to_string()));
+            };
+            let assessment = build_tree_assessment_by_code(&mut g, &tree_code).map_err(internal_error)?;
+            let timeline = g.get_tree_timeline(&tree_code).map_err(internal_error)?;
+            Ok(json!({
+                "status": "ok",
+                "tool": "query_tree_profile",
+                "tree": tree,
+                "assessment": assessment,
+                "timeline": take_limit(timeline, limit),
+                "metadata": tool_metadata("cloud_db")
+            }))
+        });
+
+    result
+}
+
+fn handle_tree_timeline(query: &str, db: Arc<Mutex<DbManager>>) -> Result<Value, Value> {
+    let params = parse_query_params(query);
+    let tree_code = required_param(&params, "tree_code")?;
+    let limit = limit_param(&params, 20);
+
+    db.lock()
+        .map_err(|_| tool_error(500, "db lock failed".to_string()))
+        .and_then(|mut g| {
+            if g.get_tree_by_code(&tree_code).map_err(internal_error)?.is_none() {
+                return Err(tool_error(404, "tree not found".to_string()));
+            }
+            let timeline = g.get_tree_timeline(&tree_code).map_err(internal_error)?;
+            Ok(json!({
+                "status": "ok",
+                "tool": "query_tree_timeline",
+                "tree_code": tree_code,
+                "limit": limit,
+                "timeline": take_limit(timeline, limit),
+                "metadata": tool_metadata("cloud_db")
+            }))
+        })
+}
+
+fn handle_plantation_report(query: &str, db: Arc<Mutex<DbManager>>) -> Result<Value, Value> {
+    let params = parse_query_params(query);
+    let plantation_id = required_i32_param(&params, "plantation_id")?;
+    let limit = limit_param(&params, 50);
+
+    db.lock()
+        .map_err(|_| tool_error(500, "db lock failed".to_string()))
+        .and_then(|mut g| {
+            let mut dashboard = build_plantation_dashboard(&mut g, plantation_id).map_err(internal_error)?;
+            limit_array_field(&mut dashboard, "trees", limit);
+            limit_array_field(&mut dashboard, "priority_trees", limit);
+            let mut blocks = build_blocks_report(&mut g, plantation_id).map_err(internal_error)?;
+            limit_block_trees(&mut blocks, limit);
+            Ok(json!({
+                "status": "ok",
+                "tool": "query_plantation_report",
+                "plantation_id": plantation_id,
+                "dashboard": dashboard,
+                "blocks_report": blocks,
+                "metadata": tool_metadata("cloud_db")
+            }))
+        })
+}
+
+fn handle_missing_evidence(query: &str, db: Arc<Mutex<DbManager>>) -> Result<Value, Value> {
+    let params = parse_query_params(query);
+    let tree_code = required_param(&params, "tree_code")?;
+
+    db.lock()
+        .map_err(|_| tool_error(500, "db lock failed".to_string()))
+        .and_then(|mut g| {
+            let Some(assessment) = build_tree_assessment_by_code(&mut g, &tree_code).map_err(internal_error)? else {
+                return Err(tool_error(404, "tree not found".to_string()));
+            };
+            let missing = assessment["missing_evidence"].as_array().cloned().unwrap_or_default();
+            let recommendations = missing
+                .iter()
+                .filter_map(|item| item.as_str())
+                .map(evidence_recommendation)
+                .collect::<Vec<_>>();
+            Ok(json!({
+                "status": "ok",
+                "tool": "query_missing_evidence",
+                "tree_code": tree_code,
+                "missing_evidence": missing,
+                "recommendations": recommendations,
+                "assessment_summary": assessment["summary"],
+                "metadata": tool_metadata("cloud_db")
+            }))
+        })
+}
+
+fn handle_patrol_report(query: &str, db: Arc<Mutex<DbManager>>) -> Result<Value, Value> {
+    let params = parse_query_params(query);
+    let plantation_id = required_i32_param(&params, "plantation_id")?;
+    let limit = limit_param(&params, 50);
+
+    db.lock()
+        .map_err(|_| tool_error(500, "db lock failed".to_string()))
+        .and_then(|mut g| {
+            let dashboard = build_plantation_dashboard(&mut g, plantation_id).map_err(internal_error)?;
+            let mut items = dashboard["trees"]
+                .as_array()
+                .cloned()
+                .unwrap_or_default()
+                .into_iter()
+                .filter_map(patrol_item_from_tree)
+                .collect::<Vec<_>>();
+            items.sort_by_key(|item| priority_rank(item["priority"].as_str().unwrap_or("low")));
+            Ok(json!({
+                "status": "ok",
+                "tool": "generate_patrol_report",
+                "plantation_id": plantation_id,
+                "generated_at": Utc::now().to_rfc3339(),
+                "limit": limit,
+                "items": take_limit(items, limit),
+                "metadata": tool_metadata("cloud_db")
+            }))
+        })
+}
+
+fn handle_explain_prediction(body: &[u8]) -> Result<Value, Value> {
+    let parsed: Value = serde_json::from_slice(body)
+        .map_err(|err| tool_error(400, format!("invalid json body: {err}")))?;
+    let prediction = parsed
+        .get("result_json")
+        .or_else(|| parsed.get("prediction"))
+        .unwrap_or(&parsed);
+
+    let label = first_label(prediction).unwrap_or_else(|| "unknown".to_string());
+    let image_role = prediction["metadata"]["image_role"]
+        .as_str()
+        .or_else(|| parsed["image_role"].as_str())
+        .unwrap_or("unknown");
+    let confidence = first_confidence(prediction);
+    let explanation = explanation_for(image_role, &label, confidence);
+
+    Ok(json!({
+        "status": "ok",
+        "tool": "explain_prediction",
+        "explanation": explanation,
+        "metadata": {
+            "read_only": true,
+            "deterministic": true,
+            "mock_safe": true,
+            "generated_at": Utc::now().to_rfc3339()
+        }
+    }))
+}
+
+fn tool_manifest() -> Value {
+    json!({
+        "status": "ok",
+        "base_path": "/api/v1/openclaw/tools",
+        "read_only": true,
+        "max_limit": MAX_TOOL_LIMIT,
+        "tools": [
+            {"name":"query_tree_profile","method":"GET","path":"/tree-profile","params":["tree_code","limit?"],"description":"Fetch tree profile, assessment, and recent timeline evidence."},
+            {"name":"query_tree_timeline","method":"GET","path":"/tree-timeline","params":["tree_code","limit?"],"description":"Fetch coordinate history timeline for one tree."},
+            {"name":"query_plantation_report","method":"GET","path":"/plantation-report","params":["plantation_id","limit?"],"description":"Fetch plantation dashboard and block report summaries."},
+            {"name":"query_missing_evidence","method":"GET","path":"/missing-evidence","params":["tree_code"],"description":"List missing evidence dimensions and collection recommendations."},
+            {"name":"explain_prediction","method":"POST","path":"/explain-prediction","params":["result_json"],"description":"Deterministically explain a mock prediction without claiming diagnosis."},
+            {"name":"generate_patrol_report","method":"GET","path":"/patrol-report","params":["plantation_id","limit?"],"description":"List priority trees for field patrol."}
+        ],
+        "safety": {
+            "writes_database": false,
+            "runs_models": false,
+            "diagnosis_policy": "suspected_not_confirmed",
+            "source_of_truth": "cloud structured APIs and database"
+        }
+    })
+}
+
+fn parse_query_params(query: &str) -> HashMap<String, String> {
+    let mut map = HashMap::new();
+    for pair in query.split('&') {
+        if pair.is_empty() {
+            continue;
+        }
+        if let Some((k, v)) = pair.split_once('=') {
+            map.insert(k.to_string(), v.to_string());
+        }
+    }
+    map
+}
+
+fn required_param(params: &HashMap<String, String>, key: &str) -> Result<String, Value> {
+    params
+        .get(key)
+        .map(|v| v.trim().to_string())
+        .filter(|v| !v.is_empty())
+        .ok_or_else(|| tool_error(400, format!("{key} is required")))
+}
+
+fn required_i32_param(params: &HashMap<String, String>, key: &str) -> Result<i32, Value> {
+    let raw = required_param(params, key)?;
+    raw.parse::<i32>()
+        .map_err(|_| tool_error(400, format!("{key} must be an integer")))
+}
+
+fn limit_param(params: &HashMap<String, String>, default_value: usize) -> usize {
+    params
+        .get("limit")
+        .and_then(|v| v.parse::<usize>().ok())
+        .unwrap_or(default_value)
+        .clamp(1, MAX_TOOL_LIMIT)
+}
+
+fn take_limit(items: Vec<Value>, limit: usize) -> Vec<Value> {
+    items.into_iter().take(limit).collect()
+}
+
+fn limit_array_field(value: &mut Value, field: &str, limit: usize) {
+    if let Some(items) = value[field].as_array_mut() {
+        items.truncate(limit);
+    }
+}
+
+fn limit_block_trees(value: &mut Value, limit: usize) {
+    for block in value["blocks"].as_array_mut().into_iter().flatten() {
+        if let Some(items) = block["trees"].as_array_mut() {
+            items.truncate(limit);
+        }
+    }
+}
+
+fn evidence_recommendation(name: &str) -> Value {
+    match name {
+        "fruit" => json!({"evidence":"fruit","action":"capture_fruit_image","image_role":"fruit"}),
+        "disease" => json!({"evidence":"disease","action":"capture_trunk_base_image","image_role":"trunk_base","risk_language":"suspected_not_confirmed"}),
+        "growth" => json!({"evidence":"growth","action":"capture_crown_image","image_role":"crown"}),
+        "uav" => json!({"evidence":"uav","action":"run_or_match_uav_mission","image_role":"uav"}),
+        _ => json!({"evidence":name,"action":"collect_more_evidence"}),
+    }
+}
+
+fn patrol_item_from_tree(tree: Value) -> Option<Value> {
+    let action = tree["recommended_action"].as_str().unwrap_or("wait");
+    if action == "wait" || action == "inactive" {
+        return None;
+    }
+    let priority = match action {
+        "inspect_disease" => "high",
+        "harvest" => "high",
+        "recheck" => "medium",
+        "collect_more_evidence" => "medium",
+        _ => "low",
+    };
+    Some(json!({
+        "tree_code": tree["tree_code"],
+        "block_id": tree["block_id"],
+        "priority": priority,
+        "recommended_action": action,
+        "reason": tree["summary"],
+        "valid_until": tree["valid_until"]
+    }))
+}
+
+fn priority_rank(priority: &str) -> u8 {
+    match priority {
+        "high" => 0,
+        "medium" => 1,
+        _ => 2,
+    }
+}
+
+fn first_label(value: &Value) -> Option<String> {
+    value["results"]
+        .as_array()
+        .and_then(|items| items.first())
+        .and_then(|item| item["label"].as_str())
+        .or_else(|| value["label"].as_str())
+        .map(|s| s.to_string())
+}
+
+fn first_confidence(value: &Value) -> Option<f64> {
+    value["results"]
+        .as_array()
+        .and_then(|items| items.first())
+        .and_then(|item| item["confidence"].as_f64())
+        .or_else(|| value["confidence"].as_f64())
+}
+
+fn explanation_for(image_role: &str, label: &str, confidence: Option<f64>) -> Value {
+    let conf_text = confidence
+        .map(|v| format!("{:.2}", v))
+        .unwrap_or_else(|| "unknown".to_string());
+    match image_role {
+        "trunk_base" => json!({
+            "summary": format!("The trunk-base mock result is '{label}' with confidence {conf_text}. Treat this as a suspected risk signal, not a confirmed diagnosis."),
+            "risk_language": "suspected_not_confirmed",
+            "next_action": "schedule_field_inspection",
+            "evidence": [{"image_role":"trunk_base","label":label,"confidence":confidence}]
+        }),
+        "fruit" => json!({
+            "summary": format!("The fruit mock result is '{label}' with confidence {conf_text}. Use it as harvest-readiness evidence only after field verification."),
+            "risk_language": "not_applicable",
+            "next_action": if label == "ripe" || label == "overripe" { "verify_and_harvest" } else { "monitor" },
+            "evidence": [{"image_role":"fruit","label":label,"confidence":confidence}]
+        }),
+        "crown" => json!({
+            "summary": format!("The crown mock result is '{label}' with confidence {conf_text}. Use it as growth/vigor evidence, not as a full tree diagnosis."),
+            "risk_language": "not_applicable",
+            "next_action": "monitor_growth",
+            "evidence": [{"image_role":"crown","label":label,"confidence":confidence}]
+        }),
+        _ => json!({
+            "summary": format!("The mock result is '{label}' with confidence {conf_text}. Interpret it as structured evidence for the tree record."),
+            "risk_language": "suspected_not_confirmed",
+            "next_action": "review_evidence",
+            "evidence": [{"image_role":image_role,"label":label,"confidence":confidence}]
+        }),
+    }
+}
+
+fn tool_metadata(source: &str) -> Value {
+    json!({
+        "read_only": true,
+        "source": source,
+        "mock_assessment": true,
+        "generated_at": Utc::now().to_rfc3339()
+    })
+}
+
+fn internal_error(err: String) -> Value {
+    tool_error(500, err)
+}
+
+fn tool_error(status: u16, message: String) -> Value {
+    json!({
+        "status": "error",
+        "http_status": status,
+        "message": message
+    })
+}
+
+fn respond_json(request: Request, status: u16, body: &Value) {
+    let response = Response::from_string(body.to_string())
+        .with_status_code(status)
+        .with_header(tiny_http::Header::from_bytes(&b"Content-Type"[..], &b"application/json"[..]).unwrap());
+    let _ = request.respond(response);
+}

--- a/doc/openclaw-tool-manifest.example.json
+++ b/doc/openclaw-tool-manifest.example.json
@@ -1,0 +1,71 @@
+{
+  "description": "Example only. Adapt this to the real /root/.openclaw/openclaw.json or agent tool format on the cloud host.",
+  "baseUrl": "http://127.0.0.1:8088/api/v1/openclaw/tools",
+  "safety": {
+    "readOnly": true,
+    "databaseWrites": false,
+    "directDatabaseAccess": false,
+    "diagnosisPolicy": "suspected_not_confirmed",
+    "maxReturnedItems": 50
+  },
+  "tools": [
+    {
+      "name": "query_tree_profile",
+      "method": "GET",
+      "url": "{{baseUrl}}/tree-profile",
+      "parameters": {
+        "tree_code": { "type": "string", "required": true },
+        "limit": { "type": "integer", "required": false, "default": 10, "maximum": 50 }
+      },
+      "description": "Fetch a tree profile, current assessment, and bounded recent timeline evidence."
+    },
+    {
+      "name": "query_tree_timeline",
+      "method": "GET",
+      "url": "{{baseUrl}}/tree-timeline",
+      "parameters": {
+        "tree_code": { "type": "string", "required": true },
+        "limit": { "type": "integer", "required": false, "default": 20, "maximum": 50 }
+      },
+      "description": "Fetch UAV coordinate history for one tree."
+    },
+    {
+      "name": "query_plantation_report",
+      "method": "GET",
+      "url": "{{baseUrl}}/plantation-report",
+      "parameters": {
+        "plantation_id": { "type": "integer", "required": true },
+        "limit": { "type": "integer", "required": false, "default": 50, "maximum": 50 }
+      },
+      "description": "Fetch plantation dashboard and block report summaries."
+    },
+    {
+      "name": "query_missing_evidence",
+      "method": "GET",
+      "url": "{{baseUrl}}/missing-evidence",
+      "parameters": {
+        "tree_code": { "type": "string", "required": true }
+      },
+      "description": "List missing evidence dimensions and recommended capture actions for one tree."
+    },
+    {
+      "name": "explain_prediction",
+      "method": "POST",
+      "url": "{{baseUrl}}/explain-prediction",
+      "parameters": {
+        "result_json": { "type": "object", "required": true }
+      },
+      "description": "Explain a mock prediction deterministically without claiming diagnosis."
+    },
+    {
+      "name": "generate_patrol_report",
+      "method": "GET",
+      "url": "{{baseUrl}}/patrol-report",
+      "parameters": {
+        "plantation_id": { "type": "integer", "required": true },
+        "limit": { "type": "integer", "required": false, "default": 50, "maximum": 50 }
+      },
+      "description": "Return priority trees for field patrol."
+    }
+  ]
+}

--- a/doc/openclaw-tools.md
+++ b/doc/openclaw-tools.md
@@ -1,0 +1,88 @@
+# OpenClaw Tools Integration
+
+This document describes the repository-side contract for Sprint F. It does not
+replace the real cloud host OpenClaw configuration under `/root/.openclaw/`.
+
+## Goal
+
+OpenClaw should answer agricultural questions from structured cloud facts
+instead of guessing from chat history. The cloud service exposes read-only tool
+APIs under:
+
+```text
+http://127.0.0.1:8088/api/v1/openclaw/tools
+```
+
+The tools reuse existing tree, session, UAV, assessment, plantation dashboard,
+and block report data. They do not run real models and do not write database
+state.
+
+## Tool Endpoints
+
+```text
+GET  /api/v1/openclaw/tools/manifest
+GET  /api/v1/openclaw/tools/tree-profile?tree_code=OP-000001&limit=10
+GET  /api/v1/openclaw/tools/tree-timeline?tree_code=OP-000001&limit=20
+GET  /api/v1/openclaw/tools/plantation-report?plantation_id=1&limit=50
+GET  /api/v1/openclaw/tools/missing-evidence?tree_code=OP-000001
+GET  /api/v1/openclaw/tools/patrol-report?plantation_id=1&limit=50
+POST /api/v1/openclaw/tools/explain-prediction
+```
+
+`limit` is capped at 50 to keep OpenClaw context bounded.
+
+## Safety Contract
+
+- The tools are read-only.
+- The tools do not call OpenClaw.
+- The tools do not train or run real models.
+- OpenClaw should not connect directly to the database.
+- Disease language must stay in `suspected` / risk wording unless a future
+  verified expert workflow says otherwise.
+- Real `/root/.openclaw/openclaw.json` files, model credentials, and provider
+  settings must not be committed to this repository.
+
+## Cloud Authentication
+
+These endpoints are under `/api/v1/*`, so when `CLOUD_AUTH_ENABLED=true` they
+follow the existing cloud auth gate. On the cloud host, either keep access local
+to `127.0.0.1` in a trusted service boundary or configure OpenClaw/adapter to
+send the required cloud auth token.
+
+Do not add a public unauthenticated path for these tools.
+
+## Local Verification
+
+After deploying cloud, verify the tool layer before changing OpenClaw config:
+
+```bash
+curl "http://127.0.0.1:8088/api/v1/openclaw/tools/manifest"
+curl "http://127.0.0.1:8088/api/v1/openclaw/tools/tree-profile?tree_code=OP-000001"
+curl "http://127.0.0.1:8088/api/v1/openclaw/tools/missing-evidence?tree_code=OP-000001"
+curl "http://127.0.0.1:8088/api/v1/openclaw/tools/patrol-report?plantation_id=1"
+```
+
+Only after these return structured JSON should `/root/.openclaw/` be updated.
+
+## OpenClaw Registration Template
+
+Use `doc/openclaw-tool-manifest.example.json` as a template for the cloud-side
+tool registration. The exact format may need to be adapted to the installed
+OpenClaw version. Keep the real file on the cloud host.
+
+Suggested behavior for the main agent:
+
+- For tree questions, call `query_tree_profile` first.
+- For evidence gaps, call `query_missing_evidence`.
+- For patrol planning, call `generate_patrol_report`.
+- For plantation summaries, call `query_plantation_report`.
+- For AI result explanation, call `explain_prediction`.
+- If a tool returns `status=error`, report the error and ask for a valid
+  `tree_code` or `plantation_id`; do not invent facts.
+
+## Example Questions
+
+- `查询 OP-000001 的树档案`
+- `这棵树缺少哪些证据？`
+- `今天优先巡检哪些树？`
+- `解释这张 trunk_base 图片的 mock 结果`

--- a/tests/test_uav_api.py
+++ b/tests/test_uav_api.py
@@ -466,3 +466,102 @@ def test_tree_assessment_and_plantation_reports():
     report = res.json()["report"]
     assert report["plantation_id"] == plantation_id
     assert len(report["blocks"]) >= 1
+
+
+def test_openclaw_tools_read_only_reports():
+    """E2E: OpenClaw tool endpoints expose bounded read-only tree facts."""
+    plantation_name = f"openclaw_tools_{int(time.time())}"
+    res = requests.post(
+        f"{BASE_URL}/api/v1/uav/missions",
+        json={
+            "plantation_id": 0,
+            "plantation_name": plantation_name,
+            "mission_name": "openclaw_seed",
+        },
+    )
+    assert res.status_code == 200
+    mission_id = res.json()["mission_id"]
+    plantation_id = res.json()["plantation_id"]
+
+    res = requests.post(f"{BASE_URL}/api/v1/uav/missions/{mission_id}/orthomosaic")
+    assert res.status_code == 200
+    ortho_id = res.json()["orthomosaic_id"]
+
+    res = requests.post(f"{BASE_URL}/api/v1/uav/orthomosaics/{ortho_id}/detections/mock")
+    assert res.status_code == 200
+    res = requests.get(f"{BASE_URL}/api/v1/uav/orthomosaics/{ortho_id}/detections")
+    det_id = res.json()["detections"][0]["id"]
+
+    res = requests.post(f"{BASE_URL}/api/v1/uav/detections/{det_id}/confirm")
+    assert res.status_code == 200
+    tree_code = res.json()["tree_code"]
+
+    res = requests.get(f"{BASE_URL}/api/v1/trees/{tree_code}")
+    tree = res.json()["tree"]
+    res = requests.post(f"{BASE_URL}/api/v1/trees/{tree['id']}/sessions")
+    assert res.status_code == 200
+    session_id = res.json()["session"]["id"]
+
+    jpeg_bytes = b"\xff\xd8\xff\xe0\x00\x10JFIF\x00\x01\x01\x00"
+    for role in ["fruit", "trunk_base", "crown"]:
+        res = requests.post(
+            f"{BASE_URL}/api/v1/sessions/{session_id}/images",
+            data={"image_role": role},
+            files={"file": (f"{role}.jpg", jpeg_bytes, "image/jpeg")},
+        )
+        assert res.status_code == 200
+
+    res = requests.get(f"{BASE_URL}/api/v1/openclaw/tools/manifest")
+    assert res.status_code == 200
+    manifest = res.json()
+    assert manifest["read_only"] is True
+    assert any(tool["name"] == "query_tree_profile" for tool in manifest["tools"])
+
+    res = requests.get(f"{BASE_URL}/api/v1/openclaw/tools/tree-profile?tree_code={tree_code}&limit=1")
+    assert res.status_code == 200
+    profile = res.json()
+    assert profile["tool"] == "query_tree_profile"
+    assert profile["tree"]["tree_code"] == tree_code
+    assert profile["metadata"]["read_only"] is True
+    assert len(profile["timeline"]) <= 1
+
+    res = requests.get(f"{BASE_URL}/api/v1/openclaw/tools/tree-timeline?tree_code={tree_code}&limit=1")
+    assert res.status_code == 200
+    timeline = res.json()
+    assert timeline["tool"] == "query_tree_timeline"
+    assert len(timeline["timeline"]) <= 1
+
+    res = requests.get(f"{BASE_URL}/api/v1/openclaw/tools/missing-evidence?tree_code={tree_code}")
+    assert res.status_code == 200
+    missing = res.json()
+    assert missing["tool"] == "query_missing_evidence"
+    assert "uav" in missing["missing_evidence"]
+    assert any(item["evidence"] == "uav" for item in missing["recommendations"])
+
+    res = requests.get(
+        f"{BASE_URL}/api/v1/openclaw/tools/plantation-report?plantation_id={plantation_id}&limit=1"
+    )
+    assert res.status_code == 200
+    report = res.json()
+    assert report["tool"] == "query_plantation_report"
+    assert len(report["dashboard"]["trees"]) <= 1
+
+    res = requests.get(f"{BASE_URL}/api/v1/openclaw/tools/patrol-report?plantation_id={plantation_id}&limit=50")
+    assert res.status_code == 200
+    patrol = res.json()
+    assert patrol["tool"] == "generate_patrol_report"
+    assert len(patrol["items"]) <= 50
+
+    res = requests.post(
+        f"{BASE_URL}/api/v1/openclaw/tools/explain-prediction",
+        json={
+            "result_json": {
+                "metadata": {"image_role": "trunk_base"},
+                "results": [{"label": "suspected_early", "confidence": 0.82}],
+            }
+        },
+    )
+    assert res.status_code == 200
+    explanation = res.json()["explanation"]
+    assert explanation["risk_language"] == "suspected_not_confirmed"
+    assert "not a confirmed diagnosis" in explanation["summary"]


### PR DESCRIPTION
## Summary

- Adds read-only Cloud tool endpoints under `/api/v1/openclaw/tools/*` for OpenClaw integration.
- Reuses existing tree profile, timeline, assessment, plantation dashboard, block report, and mock prediction data.
- Adds E2E coverage for the tool APIs and documents cloud-side OpenClaw registration guidance.

## Safety / Scope

- No database writes.
- No new migrations.
- No real model training or inference integration.
- Does not modify real cloud `/root/.openclaw` configuration; only includes docs/templates.

## Verification

- `cargo check`
- `git diff --check`
- JSON parse check for `doc/openclaw-tool-manifest.example.json`
- AST syntax check for `tests/test_uav_api.py`

## Notes

After deployment, verify endpoints with curl before registering the tool template in the cloud OpenClaw config.