### PR TITLE
fix(release): align cloud rand version for 20260426-main reproducible build

### DIFF
--- a/cloud/Cargo.toml
+++ b/cloud/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2021"
 serde = { version = "1.0", features = ["derive"] }
 toml = "1.1.2"
 serde_json = "1.0"
-rand = "0.10"
+rand = "0.8"
 sha2 = "0.10"
 tiny_http = "0.12"
 chrono = { version = "0.4", default-features = false, features = ["std", "clock"] }


### PR DESCRIPTION
## Summary
- fix release build break in `cloud`
- align `rand` dependency with source API usage

## Change
- `cloud/Cargo.toml`
  - `rand = "0.10"` -> `rand = "0.8"`

## Why
`release-20260426-main` source uses `rand 0.8` API (`rand::distributions::Alphanumeric`, `thread_rng`) but dependency was pinned to `0.10`, causing compile failure.

## Validation
- Before: `cargo check --manifest-path cloud/Cargo.toml` failed with unresolved imports from `rand`.
- After: same command passes (non-blocking warnings only).

## Scope
- only dependency alignment for release reproducibility
- no behavior change intended
