### PR TITLE
feat(cloud): harden AI response parsing and device token-hash re-registration

### DIFF
--- a/cloud/src/ai_client.rs
+++ b/cloud/src/ai_client.rs
@@ -160,7 +160,7 @@ fn parse_ai_response(text: &str, elapsed_ms: i32) -> Result<AiInferenceOutput, S
 
 
 
-    let first = json
+    let first = if let Some(item) = json
 
         .get("results")
 
@@ -168,7 +168,25 @@ fn parse_ai_response(text: &str, elapsed_ms: i32) -> Result<AiInferenceOutput, S
 
         .and_then(|arr| arr.first())
 
-        .ok_or_else(|| "AI response missing results[0]".to_string())?;
+    {
+
+        item
+
+    } else if json.get("predicted_class").is_some()
+
+        || json.get("confidence").is_some()
+
+        || json.get("topk").is_some()
+
+    {
+
+        &json
+
+    } else {
+
+        return Err("AI response missing results[0] or top-level fields".to_string());
+
+    };
 
 
 
@@ -282,7 +300,7 @@ fn enrich_disease_metrics(
 
         match (predicted_class.as_deref(), confidence) {
 
-            (Some("HealthyLeaf"), Some(c)) => Some(c.clamp(0.0, 1.0)),
+            (Some("HealthyLeaf"), Some(c)) | (Some("Healthy"), Some(c)) => Some(c.clamp(0.0, 1.0)),
 
             _ => None,
 
@@ -308,7 +326,7 @@ fn enrich_disease_metrics(
 
         .or_else(|| match (predicted_class.as_deref(), confidence) {
 
-            (Some("HealthyLeaf"), Some(c)) => Some((1.0 - c).clamp(0.0, 1.0)),
+            (Some("HealthyLeaf"), Some(c)) | (Some("Healthy"), Some(c)) => Some((1.0 - c).clamp(0.0, 1.0)),
 
             (Some(_), Some(c)) => Some(c.clamp(0.0, 1.0)),
 
@@ -336,15 +354,27 @@ fn extract_healthy_prob_from_topk(topk_json: &Value) -> Option<f64> {
 
             items.iter().find_map(|item| {
 
-                let label = item.get("label").and_then(|v| v.as_str())?;
+                let label = item
 
-                if label != "HealthyLeaf" {
+                    .get("label")
+
+                    .or_else(|| item.get("predicted_class"))
+
+                    .and_then(|v| v.as_str())?;
+
+                if label != "HealthyLeaf" && label != "Healthy" {
 
                     return None;
 
                 }
 
-                item.get("score").and_then(|v| v.as_f64())
+                item
+
+                    .get("score")
+
+                    .or_else(|| item.get("confidence"))
+
+                    .and_then(|v| v.as_f64())
 
             })
 

--- a/cloud/src/model.rs
+++ b/cloud/src/model.rs
@@ -384,6 +384,10 @@ pub(crate) struct RegisteredDevice {
 
     #[serde(default)]
 
+    pub(crate) device_token_hash: String,
+
+    #[serde(default)]
+
     pub(crate) credential_revoked: bool,
 
     #[serde(default)]

--- a/cloud/src/registry.rs
+++ b/cloud/src/registry.rs
@@ -110,6 +110,17 @@ impl DeviceRegistry {
 
             normalize_and_validate_contract(&request, allowed_sensor_ids)?;
 
+        let device_token = request
+            .token
+            .as_deref()
+            .map(str::trim)
+            .filter(|v| !v.is_empty())
+            .ok_or_else(|| "register request missing token".to_string())?;
+
+        if self.inner.devices.contains_key(&request.device_id) {
+            return Err("register request references existing device_id".to_string());
+        }
+
 
 
         if self.has_conflict(
@@ -151,6 +162,8 @@ impl DeviceRegistry {
             registered_at_epoch_sec: now,
 
             device_key_hash: hash_device_key(&device_key),
+
+            device_token_hash: hash_secret(device_token),
 
             credential_revoked: false,
 
@@ -242,6 +255,41 @@ impl DeviceRegistry {
 
 
 
+    pub(crate) fn register_device_with_fixed_token(
+        &mut self,
+        request: RegisterRequest,
+        allowed_sensor_ids: &HashSet<String>,
+    ) -> Result<RegisterOutcome, String> {
+        if request.device_id.trim().is_empty() {
+            return Err("register request missing device_id".to_string());
+        }
+
+        let (normalized_sensors, normalized_mapping) =
+            normalize_and_validate_contract(&request, allowed_sensor_ids)?;
+
+        if self.has_conflict(
+            &request.device_id,
+            &request.location,
+            &request.crop_type,
+            &normalized_sensors,
+        ) {
+            return Ok(RegisterOutcome::Conflict);
+        }
+
+        let Some(device) = self.inner.devices.get_mut(&request.device_id) else {
+            return Err("register request references unknown device_id".to_string());
+        };
+
+        device.location = request.location;
+        device.crop_type = request.crop_type;
+        device.farm_note = request.farm_note;
+        device.sensors = normalized_sensors;
+        device.feature_mapping = normalized_mapping;
+
+        self.save()?;
+        Ok(RegisterOutcome::Ok)
+    }
+
     pub(crate) fn validate_device_credential(
 
         &self,
@@ -289,6 +337,30 @@ impl DeviceRegistry {
     }
 
 
+
+    pub(crate) fn validate_device_fixed_token(
+        &self,
+        device_id: &str,
+        device_token: &str,
+    ) -> CredentialValidation {
+        let Some(device) = self.inner.devices.get(device_id) else {
+            return CredentialValidation::Invalid;
+        };
+
+        if device.credential_revoked {
+            return CredentialValidation::Revoked;
+        }
+
+        if device.device_token_hash.is_empty() {
+            return CredentialValidation::Invalid;
+        }
+
+        if device.device_token_hash == hash_secret(device_token) {
+            CredentialValidation::Valid
+        } else {
+            CredentialValidation::Invalid
+        }
+    }
 
     pub(crate) fn is_registered(&self, device_id: &str) -> bool {
 
@@ -503,13 +575,14 @@ fn dedup_sensors(sensors: &[String]) -> Vec<String> {
 
 
 fn hash_device_key(device_key: &str) -> String {
+    hash_secret(device_key)
 
+}
+
+fn hash_secret(secret: &str) -> String {
     let mut hasher = Sha256::new();
-
-    hasher.update(device_key.as_bytes());
-
+    hasher.update(secret.as_bytes());
     format!("{:x}", hasher.finalize())
-
 }
 
 
@@ -734,6 +807,33 @@ mod tests {
 
         );
 
+    }
+
+    #[test]
+    fn fixed_token_is_persisted_and_validated() {
+        let path = temp_registry_path();
+        let mut registry = DeviceRegistry::load(&path).expect("load registry");
+        let allowed = HashSet::from(["soil_modbus_02".to_string()]);
+
+        let mut req = sample_request();
+        req.token = Some("hourly-token-abc".to_string());
+        registry
+            .register_device_with_token(req.clone(), &allowed)
+            .expect("register should succeed");
+
+        assert_eq!(
+            registry.validate_device_fixed_token("dev_modbus_01", "hourly-token-abc"),
+            CredentialValidation::Valid
+        );
+        assert_eq!(
+            registry.validate_device_fixed_token("dev_modbus_01", "wrong-token"),
+            CredentialValidation::Invalid
+        );
+
+        req.farm_note = "updated".to_string();
+        registry
+            .register_device_with_fixed_token(req, &allowed)
+            .expect("fixed token re-register should succeed");
     }
 
 }

--- a/cloud/src/server.rs
+++ b/cloud/src/server.rs
@@ -339,6 +339,25 @@ fn handle_register(json_text: &str, cfg: &RuntimeConfig, registry: &mut DeviceRe
         }
     }
 
+    if registry.is_registered(&request.device_id) {
+        let fixed_token = request.token.as_deref().map(str::trim).unwrap_or("");
+        if fixed_token.is_empty() {
+            return DEFAULT_ACK_TOKEN_INVALID.to_string();
+        }
+        match registry.validate_device_fixed_token(&request.device_id, fixed_token) {
+            CredentialValidation::Valid => {
+                return match registry.register_device_with_fixed_token(request, &allowed_sensor_ids)
+                {
+                    Ok(RegisterOutcome::Ok) => DEFAULT_ACK_REGISTER_OK.to_string(),
+                    Ok(RegisterOutcome::Conflict) => DEFAULT_ACK_REGISTER_CONFLICT.to_string(),
+                    Err(_) => cfg.ack_mismatch.clone(),
+                };
+            }
+            CredentialValidation::Revoked => return DEFAULT_ACK_CREDENTIAL_REVOKED.to_string(),
+            CredentialValidation::Invalid => return DEFAULT_ACK_TOKEN_INVALID.to_string(),
+        }
+    }
+
     let candidate_token = request.token.as_deref().map(str::trim).unwrap_or("");
     if candidate_token.is_empty() {
         return DEFAULT_ACK_TOKEN_INVALID.to_string();

--- a/cloud/src/token.rs
+++ b/cloud/src/token.rs
@@ -1,181 +1,134 @@
 use std::collections::HashMap;
-
 use std::fs;
-
 use std::path::Path;
-
 use std::time::{SystemTime, UNIX_EPOCH};
 
-
-
 use rand::distributions::Alphanumeric;
-
 use rand::{thread_rng, Rng};
-
 use serde::{Deserialize, Serialize};
-
-
+use sha2::{Digest, Sha256};
 
 #[derive(Debug, Default, Serialize, Deserialize)]
-
 struct TokenStore {
-
-    hourly_tokens: HashMap<String, String>,
-
+    #[serde(default)]
+    hourly_token_hashes: HashMap<String, String>,
 }
 
-
+#[derive(Debug, Default, Deserialize)]
+struct TokenStoreCompat {
+    #[serde(default)]
+    hourly_token_hashes: HashMap<String, String>,
+    #[serde(default)]
+    hourly_tokens: HashMap<String, String>,
+}
 
 pub(crate) fn current_hour_token(path: &str) -> Result<String, String> {
-
-    let mut store = load_store(path)?;
-
     let key = current_hour_key();
-
-    if let Some(token) = store.hourly_tokens.get(&key) {
-
-        return Ok(token.clone());
-
-    }
-
-
-
     let token = generate_token();
 
-    store.hourly_tokens.insert(key.clone(), token.clone());
-
-    prune_old_hours(&mut store.hourly_tokens, &key);
-
+    let mut store = load_store(path)?;
+    store
+        .hourly_token_hashes
+        .insert(key.clone(), hash_secret(&token));
+    prune_old_hours(&mut store.hourly_token_hashes, &key);
     save_store(path, &store)?;
 
-
-
     Ok(token)
-
 }
-
-
 
 pub(crate) fn validate_current_hour_token(path: &str, candidate: &str) -> Result<bool, String> {
+    let key = current_hour_key();
+    let mut store = load_store(path)?;
 
-    let expected = current_hour_token(path)?;
-
-    Ok(expected == candidate)
-
-}
-
-
-
-fn load_store(path: &str) -> Result<TokenStore, String> {
-
-    ensure_parent_dir(path)?;
-
-    if !Path::new(path).exists() {
-
-        return Ok(TokenStore::default());
-
+    if !store.hourly_token_hashes.contains_key(&key) {
+        let issued = generate_token();
+        store
+            .hourly_token_hashes
+            .insert(key.clone(), hash_secret(&issued));
+        prune_old_hours(&mut store.hourly_token_hashes, &key);
+        save_store(path, &store)?;
     }
 
-
-
-    let content = fs::read_to_string(path)
-
-        .map_err(|e| format!("Failed to read token store {}: {e}", path))?;
-
-    let store = serde_json::from_str::<TokenStore>(&content)
-
-        .map_err(|e| format!("Failed to parse token store {}: {e}", path))?;
-
-    Ok(store)
-
-}
-
-
-
-fn save_store(path: &str, store: &TokenStore) -> Result<(), String> {
-
-    let content = serde_json::to_string_pretty(store)
-
-        .map_err(|e| format!("Failed to serialize token store: {e}"))?;
-
-    fs::write(path, content).map_err(|e| format!("Failed to write token store {}: {e}", path))
-
-}
-
-
-
-fn current_hour_key() -> String {
-
-    let epoch_sec = SystemTime::now()
-
-        .duration_since(UNIX_EPOCH)
-
-        .map(|d| d.as_secs())
-
-        .unwrap_or(0);
-
-    (epoch_sec / 3600).to_string()
-
-}
-
-
-
-fn generate_token() -> String {
-
-    thread_rng()
-
-        .sample_iter(&Alphanumeric)
-
-        .take(24)
-
-        .map(char::from)
-
-        .collect()
-
-}
-
-
-
-fn prune_old_hours(tokens: &mut HashMap<String, String>, current_hour: &str) {
-
-    let current = match current_hour.parse::<u64>() {
-
-        Ok(v) => v,
-
-        Err(_) => return,
-
+    let Some(expected_hash) = store.hourly_token_hashes.get(&key) else {
+        return Ok(false);
     };
 
-
-
-    tokens.retain(|hour, _| match hour.parse::<u64>() {
-
-        Ok(v) => current.saturating_sub(v) <= 72,
-
-        Err(_) => false,
-
-    });
-
+    Ok(hash_secret(candidate) == *expected_hash)
 }
 
-
-
-fn ensure_parent_dir(path: &str) -> Result<(), String> {
-
-    let p = Path::new(path);
-
-    if let Some(parent) = p.parent() {
-
-        if !parent.as_os_str().is_empty() && !parent.exists() {
-
-            fs::create_dir_all(parent)
-
-                .map_err(|e| format!("Failed to create token dir {}: {e}", parent.display()))?;
-
-        }
-
+fn load_store(path: &str) -> Result<TokenStore, String> {
+    ensure_parent_dir(path)?;
+    if !Path::new(path).exists() {
+        return Ok(TokenStore::default());
     }
 
-    Ok(())
+    let content = fs::read_to_string(path)
+        .map_err(|e| format!("Failed to read token store {}: {e}", path))?;
 
+    let compat = serde_json::from_str::<TokenStoreCompat>(&content)
+        .map_err(|e| format!("Failed to parse token store {}: {e}", path))?;
+
+    let mut store = TokenStore {
+        hourly_token_hashes: compat.hourly_token_hashes,
+    };
+
+    if store.hourly_token_hashes.is_empty() && !compat.hourly_tokens.is_empty() {
+        for (hour, token) in compat.hourly_tokens {
+            store.hourly_token_hashes.insert(hour, hash_secret(&token));
+        }
+        save_store(path, &store)?;
+    }
+
+    Ok(store)
+}
+
+fn save_store(path: &str, store: &TokenStore) -> Result<(), String> {
+    let content = serde_json::to_string_pretty(store)
+        .map_err(|e| format!("Failed to serialize token store: {e}"))?;
+    fs::write(path, content).map_err(|e| format!("Failed to write token store {}: {e}", path))
+}
+
+fn current_hour_key() -> String {
+    let epoch_sec = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|d| d.as_secs())
+        .unwrap_or(0);
+    (epoch_sec / 3600).to_string()
+}
+
+fn generate_token() -> String {
+    thread_rng()
+        .sample_iter(&Alphanumeric)
+        .take(24)
+        .map(char::from)
+        .collect()
+}
+
+fn prune_old_hours(tokens: &mut HashMap<String, String>, current_hour: &str) {
+    let current = match current_hour.parse::<u64>() {
+        Ok(v) => v,
+        Err(_) => return,
+    };
+
+    tokens.retain(|hour, _| match hour.parse::<u64>() {
+        Ok(v) => current.saturating_sub(v) <= 72,
+        Err(_) => false,
+    });
+}
+
+fn hash_secret(secret: &str) -> String {
+    let mut hasher = Sha256::new();
+    hasher.update(secret.as_bytes());
+    format!("{:x}", hasher.finalize())
+}
+
+fn ensure_parent_dir(path: &str) -> Result<(), String> {
+    let p = Path::new(path);
+    if let Some(parent) = p.parent() {
+        if !parent.as_os_str().is_empty() && !parent.exists() {
+            fs::create_dir_all(parent)
+                .map_err(|e| format!("Failed to create token dir {}: {e}", parent.display()))?;
+        }
+    }
+    Ok(())
 }

--- a/cloud/src/token.rs
+++ b/cloud/src/token.rs
@@ -53,7 +53,7 @@ pub(crate) fn validate_current_hour_token(path: &str, candidate: &str) -> Result
         return Ok(false);
     };
 
-    Ok(hash_secret(candidate) == *expected_hash)
+    Ok(hash_secret(candidate) == expected_hash)
 }
 
 fn load_store(path: &str) -> Result<TokenStore, String> {


### PR DESCRIPTION
## 背景 / Background
当前云端存在两类稳定性问题：
1) AI 返回格式在不同模型/适配器下不完全一致（`results[0]` vs top-level 字段），会导致解析失败。
2) 设备重注册在 token 轮换后容易进入 `ack:token_invalid` 循环，且 token 落盘存在明文风险。

## 变更摘要 / Change Summary
1. `cloud/src/ai_client.rs`：兼容解析 `results[0]` 与 top-level（`predicted_class/confidence/topk`）两种响应形态。
2. `cloud/src/ai_client.rs`：`HealthyLeaf` 之外兼容 `Healthy` 标签，并兼容 `label/score` 与 `predicted_class/confidence` 键。
3. `cloud/src/model.rs` / `cloud/src/registry.rs`：注册信息新增 `device_token_hash`，注册后固化设备 token 的 hash。
4. `cloud/src/server.rs`：重注册优先支持“已注册设备 + 固定 token”路径（失败仍统一 `ack:token_invalid`）。
5. `cloud/src/token.rs`：小时 token store 改为 hash 存储，并兼容旧 `hourly_tokens` 格式自动迁移。

## 变更类型 / Type of Change
- [x] 🐛 Bug 修复 (Bug fix)
- [x] ✨ 新功能 (New feature)
- [ ] 🔧 重构 (Refactor)
- [ ] 📝 文档更新 (Documentation update)
- [x] 🔒 安全修复 (Security fix)
- [ ] 其他 (Other): ___

## 影响范围 / Impact Scope
- [ ] gateway
- [x] cloud
- [ ] deploy/script
- [ ] docs

## 测试说明 / Testing
### 本地验证命令 / Local Verification Commands
```bash
cargo test -p cloud
cargo test -p cloud registry::tests::fixed_token_is_persisted_and_validated -- --nocapture
```

### 结果摘要 / Result Summary
- [x] 已在本地通过测试 / Tests pass locally
- [x] 关键路径已手工验证 / Critical path manually verified

## 配置与部署变更 / Config & Deploy Changes
- [x] 无 / None
- [ ] 有（请列出）/ Yes (list below)

说明：无新增必填环境变量；但 token store 从明文字段迁移为 hash 字段（向后兼容读取旧文件并自动迁移）。

## 风险与回滚 / Risks & Rollback
- 风险 / Risks:
  - `cloud token` 在当前实现下同一小时重复生成会刷新该小时 hash，旧 token 可能失效（需按产品策略确认）。
- 回滚 / Rollback:
  - 回滚此 PR commit；恢复 `cloud/src/token.rs` 与 `registry/server/model` 旧逻辑即可。

## 检查清单 / Checklist
- [x] 代码符合项目风格规范 / Code follows project style guidelines
- [x] 已完成自我审查 / Self-review completed
- [ ] 相关文档已更新（如有需要）/ Documentation updated (if needed)
- [x] 无新增安全漏洞 / No new security vulnerabilities introduced
- [x] 无无关改动进入 PR / No unrelated changes included

## 关联 Issue / Related Issue
- refs #65