### PR TITLE
feat: wire oil palm A0 runtime integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,6 +99,7 @@ Recommended variables:
 
 - `CLOUD_BIND_ADDR` (example: `0.0.0.0:9000`)
 - `AI_PREDICT_URL` (example: `http://ai-engine:8000/api/v1/predict`)
+- `AI_OIL_PALM_A0_DETECT_URL` (optional, example: `http://ai-engine:8000/api/v1/oil-palm/a0/detect`)
 - `OPENCLAW_URL` (example: `http://openclaw:3000`)
 - `TOKEN_STORE_PATH`, `REGISTRY_PATH`, `TELEMETRY_STORE_PATH`
 - `IMAGE_STORE_PATH`, `IMAGE_INDEX_PATH`, `IMAGE_DB_ERROR_STORE_PATH`

--- a/ai_engine/.env.example
+++ b/ai_engine/.env.example
@@ -27,5 +27,7 @@
 # OIL_PALM_FFB_MODEL_PATH=models/oil_palm/ffb_maturity/best.pt
 # OIL_PALM_UAV_CROWN_MODEL_PATH=models/oil_palm/uav_tree_crown/best.pt
 # OIL_PALM_GANODERMA_MODEL_PATH=models/oil_palm/ganoderma_risk/best.pt
-# OIL_PALM_A0_MODEL_PATH=models/oil_palm/a0_image_routing/best.pt
+# OIL_PALM_A0_MODEL_PATH=models/oil_palm/a0_image_routing/runs/a0_yolo_structure_detector_v1/weights/best.pt
+# OIL_PALM_A0_LABELS_FILE=models/oil_palm/a0_image_routing/labels.json
+# OIL_PALM_A0_CONFIG_FILE=models/oil_palm/a0_image_routing/inference_config.yaml
 # OIL_PALM_CONFIDENCE_THRESHOLD=0.5

--- a/ai_engine/README.md
+++ b/ai_engine/README.md
@@ -66,7 +66,10 @@ CROP_PROFILE=oil_palm uvicorn ai_engine.main:app --reload --host 0.0.0.0 --port 
 | `MODEL_ADVICE_FILE` | Rice advice map path | `models/rice/rice_leaf_classifier/advice_map.yaml` |
 | `CORS_ORIGINS` | Allowed dashboard/backend origins | `http://localhost:8088,http://127.0.0.1:8088` |
 | `OIL_PALM_MODEL_MODE` | Oil palm mode: `mock`, `real`, or `hybrid` | `mock` |
-| `OIL_PALM_CONFIDENCE_THRESHOLD` | Future real predictor confidence threshold | `0.5` |
+| `OIL_PALM_A0_MODEL_PATH` | A0 YOLO weights path | `models/oil_palm/a0_image_routing/runs/a0_yolo_structure_detector_v1/weights/best.pt` |
+| `OIL_PALM_A0_LABELS_FILE` | A0 YOLO labels file | `models/oil_palm/a0_image_routing/labels.json` |
+| `OIL_PALM_A0_CONFIG_FILE` | A0 inference config file | `models/oil_palm/a0_image_routing/inference_config.yaml` |
+| `OIL_PALM_CONFIDENCE_THRESHOLD` | A0 confidence threshold override | `0.5` |
 
 Future oil palm model path variables are documented in `ai_engine/.env.example`.
 `OIL_PALM_A0_MODEL_PATH` can point at the trained A0 YOLO baseline recorded in
@@ -96,16 +99,16 @@ Oil palm:
 
 ## Oil Palm Model Modes
 
-The current service still defaults to mock predictors. A trained A0 YOLO
-baseline artifact now exists, but runtime registration of a real YOLO predictor
-is intentionally separate from the data/training branch.
+The service still defaults to mock predictors. A trained A0 YOLO baseline
+artifact exists, and runtime registration is now available for A0 only.
 
 - `mock`: all tasks use mock predictors. This is the default and is safe for CI,
   demos, and environments without weights.
-- `hybrid`: safe fallback mode in this foundation branch. It still uses mock
-  predictors until a later per-task branch registers real predictors.
-- `real`: fail-fast in this foundation branch. Use it only after per-task model
-  branches implement and register real predictors.
+- `hybrid`: registers the real A0 YOLO structure detector when weights and
+  dependencies are available, then keeps downstream FFB/Ganoderma/Growth/UAV
+  predictors on safe mock fallback until their own model branches land.
+- `real`: requires the A0 YOLO predictor to load successfully. Downstream oil
+  palm predictors still advertise `mode=mock` until they are implemented.
 
 Current oil palm image role routing:
 
@@ -116,20 +119,16 @@ Current oil palm image role routing:
 | `crown` | `growth_vigor` |
 | `uav_tile` | `uav_tree_crown` |
 
-A0 structure detection is registered as a mock gatekeeper at runtime until the
-real YOLO predictor is wired in. It validates the requested `image_role`,
-returns bbox candidates, and uses `route_status` values such as
-`needs_user_confirmation`, `role_mismatch`, and
-`no_supported_structure_detected`.
+A0 structure detection can now run as a real YOLOv8 gatekeeper in `hybrid` or
+`real` mode. It validates the requested `image_role`, returns bbox candidates,
+and uses `route_status` values such as `needs_user_confirmation`,
+`role_mismatch`, and `no_supported_structure_detected`. The weights are not
+committed; mount them and point `OIL_PALM_A0_MODEL_PATH` at the mounted file.
 
 The first trained A0 YOLO baseline is documented under
-`models/oil_palm/a0_image_routing/`:
-
-- `metrics.json` records training metrics and the local ignored artifact path.
-- `inference_config.yaml` records the intended real-model runtime settings.
-- `runs/a0_yolo_structure_detector_v1/weights/best.pt` is ignored by Git and
-  must be supplied by local storage, release artifact, object storage, or a
-  deployment volume.
+`models/oil_palm/a0_image_routing/`: `metrics.json` records training metrics,
+`inference_config.yaml` records runtime settings, and
+`runs/a0_yolo_structure_detector_v1/weights/best.pt` is ignored by Git.
 
 Current A0 YOLO labels are `fruit_bunch`, `trunk_base`, and `crown_region`.
 `unknown` is an inference status, not a trained bbox class.

--- a/ai_engine/crops/oil_palm/inference/a0_yolo_predictor.py
+++ b/ai_engine/crops/oil_palm/inference/a0_yolo_predictor.py
@@ -1,0 +1,256 @@
+from __future__ import annotations
+
+import io
+import json
+import os
+from pathlib import Path
+from typing import Any
+
+import yaml
+from PIL import Image
+
+from ai_engine.common.predictors.base import BasePredictor, PredictorContext
+
+
+ROLE_TO_LABEL = {
+    "fruit": "fruit_bunch",
+    "trunk_base": "trunk_base",
+    "crown": "crown_region",
+}
+
+LABEL_TO_ROLE = {label: role for role, label in ROLE_TO_LABEL.items()}
+
+
+class A0YoloPredictor(BasePredictor):
+    crop = "oil_palm"
+    task = "a0_structure_detection"
+    mode = "real"
+
+    def __init__(
+        self,
+        *,
+        weights_path: str | Path,
+        labels_path: str | Path = "models/oil_palm/a0_image_routing/labels.json",
+        config_path: str | Path | None = "models/oil_palm/a0_image_routing/inference_config.yaml",
+        confidence_threshold: float | None = None,
+    ) -> None:
+        self.weights_path = Path(weights_path)
+        self.labels_path = Path(labels_path)
+        self.config_path = Path(config_path) if config_path else None
+        self.config = self._load_config(self.config_path)
+        self.labels = self._load_labels(self.labels_path)
+        self.model_version = str(
+            self.config.get("model_version", "oil_palm_a0_yolo_structure_detector_v1")
+        )
+        self.confidence_threshold = float(
+            confidence_threshold
+            if confidence_threshold is not None
+            else self.config.get("confidence_threshold", 0.5)
+        )
+        self.iou_threshold = float(self.config.get("iou_threshold", 0.7))
+        self.input_size = int(self.config.get("input_size", 960))
+        self.max_detections = int(self.config.get("max_detections", 300))
+
+        if not self.weights_path.exists():
+            raise FileNotFoundError(f"A0 YOLO weights not found: {self.weights_path}")
+        if not self.labels_path.exists():
+            raise FileNotFoundError(f"A0 labels file not found: {self.labels_path}")
+
+        try:
+            from ultralytics import YOLO
+        except Exception as exc:  # pragma: no cover - exercised when deps missing
+            raise RuntimeError(
+                "ultralytics is required for the real A0 YOLO predictor"
+            ) from exc
+
+        self.model = YOLO(str(self.weights_path))
+
+    def predict(self, image_bytes: bytes, context: PredictorContext) -> dict[str, Any]:
+        requested_role = (context.image_role or "").strip().lower()
+        image = Image.open(io.BytesIO(image_bytes)).convert("RGB")
+        width, height = image.size
+
+        prediction = self.model.predict(
+            source=image,
+            imgsz=self.input_size,
+            conf=self.confidence_threshold,
+            iou=self.iou_threshold,
+            max_det=self.max_detections,
+            verbose=False,
+        )
+        first = prediction[0] if prediction else None
+        candidates = self._candidates_from_result(first, width, height)
+        requested_label = ROLE_TO_LABEL.get(requested_role)
+        detected_labels = sorted({item["label"] for item in candidates})
+        detected_roles = sorted(
+            {item["suggested_role"] for item in candidates if item.get("suggested_role")}
+        )
+
+        if not candidates:
+            route_status = "no_supported_structure_detected"
+        elif requested_label is None:
+            route_status = "unsupported_requested_role"
+        elif requested_label not in detected_labels:
+            route_status = "role_mismatch"
+        else:
+            route_status = "needs_user_confirmation"
+
+        results = []
+        geometry = []
+        for item in candidates:
+            candidate_geometry = item["geometry"]
+            geometry.append(candidate_geometry)
+            results.append(
+                {
+                    "task": self.task,
+                    "label": item["label"],
+                    "confidence": item["confidence"],
+                    "geometry": candidate_geometry,
+                    "metadata": {
+                        "candidate_id": item["candidate_id"],
+                        "suggested_role": item["suggested_role"],
+                        "selected_by_default": True,
+                    },
+                }
+            )
+
+        metadata = {
+            "crop": context.crop,
+            "task": self.task,
+            "image_role": requested_role,
+            "requested_image_role": requested_role,
+            "detected_roles": detected_roles,
+            "route_status": route_status,
+            "a0_candidates": candidates,
+            "requires_user_confirmation": route_status == "needs_user_confirmation",
+            "mock": False,
+            "model_profile": "a0_yolo_structure_router",
+            "weights_path": str(self.weights_path),
+            "confidence_threshold": self.confidence_threshold,
+            "iou_threshold": self.iou_threshold,
+            **(context.metadata or {}),
+        }
+        return {
+            "status": "success",
+            "results": results,
+            "geometry": geometry,
+            "metadata": metadata,
+            "model_version": self.model_version,
+        }
+
+    def _candidates_from_result(
+        self,
+        result: Any,
+        width: int,
+        height: int,
+    ) -> list[dict[str, Any]]:
+        boxes = getattr(result, "boxes", None)
+        if boxes is None:
+            return []
+
+        xyxy_values = _to_list(getattr(boxes, "xyxy", []))
+        confidence_values = _to_list(getattr(boxes, "conf", []))
+        class_values = _to_list(getattr(boxes, "cls", []))
+        candidates: list[dict[str, Any]] = []
+
+        for idx, xyxy in enumerate(xyxy_values):
+            if len(xyxy) < 4:
+                continue
+            class_idx = int(float(class_values[idx])) if idx < len(class_values) else -1
+            if class_idx < 0 or class_idx >= len(self.labels):
+                continue
+            label = self.labels[class_idx]
+            confidence = (
+                float(confidence_values[idx]) if idx < len(confidence_values) else 0.0
+            )
+            if confidence < self.confidence_threshold:
+                continue
+            x0, y0, x1, y1 = [float(v) for v in xyxy[:4]]
+            geometry = _normalized_bbox(x0, y0, x1, y1, width, height)
+            candidates.append(
+                {
+                    "candidate_id": f"a0_{LABEL_TO_ROLE.get(label, label)}_{idx + 1:03d}",
+                    "label": label,
+                    "suggested_role": LABEL_TO_ROLE.get(label, "unknown"),
+                    "confidence": round(confidence, 4),
+                    "geometry": geometry,
+                }
+            )
+
+        return candidates
+
+    @staticmethod
+    def _load_config(path: Path | None) -> dict[str, Any]:
+        if path is None or not path.exists():
+            return {}
+        with open(path, "r", encoding="utf-8") as f:
+            data = yaml.safe_load(f) or {}
+        if not isinstance(data, dict):
+            raise ValueError(f"A0 inference config must be a mapping: {path}")
+        return data
+
+    @staticmethod
+    def _load_labels(path: Path) -> list[str]:
+        with open(path, "r", encoding="utf-8") as f:
+            labels = json.load(f)
+        if not isinstance(labels, list) or not all(isinstance(v, str) for v in labels):
+            raise ValueError(f"A0 labels must be a JSON list of strings: {path}")
+        return labels
+
+
+def build_a0_yolo_predictor_from_env() -> A0YoloPredictor:
+    weights_path = os.environ.get(
+        "OIL_PALM_A0_MODEL_PATH",
+        "models/oil_palm/a0_image_routing/runs/a0_yolo_structure_detector_v1/weights/best.pt",
+    )
+    labels_path = os.environ.get(
+        "OIL_PALM_A0_LABELS_FILE",
+        "models/oil_palm/a0_image_routing/labels.json",
+    )
+    config_path = os.environ.get(
+        "OIL_PALM_A0_CONFIG_FILE",
+        "models/oil_palm/a0_image_routing/inference_config.yaml",
+    )
+    threshold = os.environ.get("OIL_PALM_CONFIDENCE_THRESHOLD")
+    parsed_threshold = float(threshold) if threshold not in (None, "") else None
+    return A0YoloPredictor(
+        weights_path=weights_path,
+        labels_path=labels_path,
+        config_path=config_path,
+        confidence_threshold=parsed_threshold,
+    )
+
+
+def _to_list(value: Any) -> list[Any]:
+    if hasattr(value, "detach"):
+        value = value.detach()
+    if hasattr(value, "cpu"):
+        value = value.cpu()
+    if hasattr(value, "numpy"):
+        value = value.numpy()
+    if hasattr(value, "tolist"):
+        return value.tolist()
+    return list(value)
+
+
+def _normalized_bbox(
+    x0: float,
+    y0: float,
+    x1: float,
+    y1: float,
+    width: int,
+    height: int,
+) -> dict[str, Any]:
+    width = max(width, 1)
+    height = max(height, 1)
+    nx0 = max(0.0, min(x0 / width, 1.0))
+    ny0 = max(0.0, min(y0 / height, 1.0))
+    nx1 = max(0.0, min(x1 / width, 1.0))
+    ny1 = max(0.0, min(y1 / height, 1.0))
+    return {
+        "type": "bbox",
+        "x": round(min(nx0, nx1), 4),
+        "y": round(min(ny0, ny1), 4),
+        "w": round(abs(nx1 - nx0), 4),
+        "h": round(abs(ny1 - ny0), 4),
+    }

--- a/ai_engine/crops/oil_palm/pipeline.py
+++ b/ai_engine/crops/oil_palm/pipeline.py
@@ -6,6 +6,9 @@ from typing import Any
 
 from ai_engine.common.predictors.base import BasePredictor, PredictorContext
 from ai_engine.common.registry import ModelRegistry
+from ai_engine.crops.oil_palm.inference.a0_yolo_predictor import (
+    build_a0_yolo_predictor_from_env,
+)
 from ai_engine.crops.oil_palm.inference.mock_predictors import (
     A0StructureMockPredictor,
     FFBMockPredictor,
@@ -154,31 +157,44 @@ def build_default_oil_palm_pipeline() -> OilPalmPipeline:
         mode = "mock"
 
     logger.info("Building OilPalmPipeline in mode=%s", mode)
-    if mode == "real":
-        raise RuntimeError(
-            "OIL_PALM_MODEL_MODE=real is not available in "
-            "feature/oil-palm-model-data-foundation. Real oil palm predictors "
-            "must be implemented and registered by per-task model branches "
-            "(feature/ffb-maturity-model, feature/uav-crown-detection-model, "
-            "feature/ganoderma-risk-model, feature/oil-palm-a0-routing-model)."
-        )
-
     if mode == "hybrid":
         logger.info(
-            "Oil palm hybrid mode is running as safe mock fallback in the "
-            "model data foundation branch; real predictors are not registered yet."
+            "Oil palm hybrid mode will use real A0 when configured and keep "
+            "other unavailable oil palm predictors on safe mock fallback."
         )
 
     registry = ModelRegistry()
 
-    # Tasks that get registered into the pipeline
+    a0_predictor: BasePredictor | None = None
+    if mode in ("real", "hybrid"):
+        try:
+            a0_predictor = build_a0_yolo_predictor_from_env()
+            logger.info("  [a0_structure_detection] registered real YOLO predictor")
+        except Exception as exc:
+            if mode == "real":
+                raise RuntimeError(
+                    "OIL_PALM_MODEL_MODE=real requires a usable A0 YOLO predictor. "
+                    "Set OIL_PALM_A0_MODEL_PATH/OIL_PALM_A0_LABELS_FILE and install "
+                    "oil palm inference dependencies."
+                ) from exc
+            logger.warning(
+                "A0 real predictor unavailable in hybrid mode; falling back to mock: %s",
+                exc,
+            )
+
+    if a0_predictor is not None:
+        registry.register(a0_predictor)
+
+    # Tasks that get registered into the pipeline. Downstream oil palm tasks
+    # remain mock until their own real model branches land.
     tasks_to_register = [
-        "a0_structure_detection",
         "ffb_maturity",
         "ganoderma_risk",
         "growth_vigor",
         "uav_tree_crown",
     ]
+    if a0_predictor is None:
+        tasks_to_register.insert(0, "a0_structure_detection")
 
     for task in tasks_to_register:
         mock_cls = _MOCK_PREDICTORS.get(task)

--- a/cloud/README.md
+++ b/cloud/README.md
@@ -57,6 +57,10 @@ image_index_path = "state/image_index.jsonl"
 image_db_error_store_path = "state/image_upload_errors.jsonl"
 database_url = "postgres://postgres@127.0.0.1/ai_agriculture"
 ai_predict_url = "http://127.0.0.1:8000/api/v1/predict"
+# Optional: when set, observation sessions call AI Engine A0 detection before
+# bbox review. If unset or unavailable, Cloud falls back to the local mock A0
+# contract so tree-profile collection remains usable.
+# AI_OIL_PALM_A0_DETECT_URL=http://127.0.0.1:8000/api/v1/oil-palm/a0/detect
 openclaw_url = "http://127.0.0.1:3000"
 
 [[exact_payloads]]
@@ -156,7 +160,9 @@ These APIs aggregate existing structured facts. They do not run real models.
 Observation session image upload now uses an A0 confirmation step:
 
 - `POST /api/v1/sessions/{session_id}/images`
-  - saves the original image and returns mock A0 `a0_candidates`
+  - saves the original image and returns A0 `a0_candidates`
+  - calls `${AI_OIL_PALM_A0_DETECT_URL}` when configured
+  - falls back to the local mock A0 contract when the URL is unset or unavailable
   - response includes `requires_confirmation: true`
 - `POST /api/v1/sessions/{session_id}/images/{image_id}/confirm`
   - body: `{"selected_candidate_ids":["a0_fruit_001"]}`

--- a/cloud/README.md
+++ b/cloud/README.md
@@ -163,7 +163,7 @@ Observation session image upload now uses an A0 confirmation step:
   - saves the original image and returns A0 `a0_candidates`
   - calls `${AI_OIL_PALM_A0_DETECT_URL}` when configured
   - falls back to the local mock A0 contract when the URL is unset or unavailable
-  - response includes `requires_confirmation: true`
+  - response includes `requires_confirmation` based on A0 `route_status`
 - `POST /api/v1/sessions/{session_id}/images/{image_id}/confirm`
   - body: `{"selected_candidate_ids":["a0_fruit_001"]}`
   - rejected bbox candidates are masked in a derived PNG image

--- a/cloud/config/sensors.toml
+++ b/cloud/config/sensors.toml
@@ -11,6 +11,9 @@ image_index_path = "state/image_index.jsonl"
 image_db_error_store_path = "state/image_upload_errors.jsonl"
 database_url = "postgres://postgres:CHANGE_ME@db:5432/ai_agriculture"
 ai_predict_url = "http://ai-engine:8000/api/v1/predict"
+# Optional runtime A0 detector. Keep unset to use Cloud's local mock A0 fallback.
+# Set via environment in deployment:
+# AI_OIL_PALM_A0_DETECT_URL="http://ai-engine:8000/api/v1/oil-palm/a0/detect"
 openclaw_url = "http://openclaw:3000"
 
 [[exact_payloads]]

--- a/cloud/src/ai_client.rs
+++ b/cloud/src/ai_client.rs
@@ -116,6 +116,77 @@ pub(crate) fn infer_image_from_bytes(
 
 }
 
+pub(crate) fn detect_oil_palm_a0_from_bytes(
+    client: &Client,
+    detect_url: &str,
+    image_bytes: &[u8],
+    filename: Option<&str>,
+    image_type: &str,
+    image_role: &str,
+    tree_code: Option<&str>,
+    session_id: Option<&str>,
+    mock_detect_role: Option<&str>,
+) -> Result<Value, String> {
+    if image_bytes.is_empty() {
+        return Err("image bytes are empty".to_string());
+    }
+
+    let content_type = match image_type {
+        "png" => "image/png",
+        _ => "image/jpeg",
+    };
+    let part = reqwest::blocking::multipart::Part::bytes(image_bytes.to_vec())
+        .file_name(filename.unwrap_or("session-upload.bin").to_string())
+        .mime_str(content_type)
+        .map_err(|e| format!("failed to build multipart file part: {e}"))?;
+
+    let mut form = reqwest::blocking::multipart::Form::new()
+        .part("file", part)
+        .text("image_role", image_role.to_string());
+    if let Some(value) = tree_code.filter(|v| !v.is_empty()) {
+        form = form.text("tree_code", value.to_string());
+    }
+    if let Some(value) = session_id.filter(|v| !v.is_empty()) {
+        form = form.text("session_id", value.to_string());
+    }
+    if let Some(value) = mock_detect_role.filter(|v| !v.is_empty()) {
+        form = form.text("mock_detect_role", value.to_string());
+    }
+
+    let response = client
+        .post(detect_url)
+        .multipart(form)
+        .send()
+        .map_err(|e| format!("failed to call A0 detect API {}: {e}", detect_url))?;
+    let status = response.status();
+    let text = response
+        .text()
+        .map_err(|e| format!("failed to read A0 detect response body: {e}"))?;
+    if !status.is_success() {
+        return Err(format!(
+            "A0 detect API returned {} with body: {}",
+            status,
+            trim_for_log(&text)
+        ));
+    }
+
+    let json: Value = serde_json::from_str(&text).map_err(|e| {
+        format!(
+            "failed to parse A0 detect JSON response: {e}; body={}",
+            trim_for_log(&text)
+        )
+    })?;
+    if json
+        .get("status")
+        .and_then(|v| v.as_str())
+        .map(|v| v == "error")
+        .unwrap_or(false)
+    {
+        return Err(format!("A0 detect status=error: {}", trim_for_log(&text)));
+    }
+    Ok(json)
+}
+
 
 
 fn parse_ai_response(text: &str, elapsed_ms: i32) -> Result<AiInferenceOutput, String> {

--- a/cloud/src/http_server.rs
+++ b/cloud/src/http_server.rs
@@ -372,6 +372,10 @@ pub fn start_http_server(
             .build()
             .expect("Failed to build AI HTTP client"),
     );
+    let ai_oil_palm_a0_detect_url = std::env::var("AI_OIL_PALM_A0_DETECT_URL")
+        .ok()
+        .map(|v| v.trim().to_string())
+        .filter(|v| !v.is_empty());
     let openclaw_http_client = Arc::new(
         reqwest::blocking::Client::builder()
             .timeout(Duration::from_secs(openclaw_timeout_sec))
@@ -413,6 +417,7 @@ pub fn start_http_server(
             let image_index_path = image_index_path.clone();
             let image_db_error_store_path = image_db_error_store_path.clone();
             let ai_predict_url = ai_predict_url.clone();
+            let ai_oil_palm_a0_detect_url = ai_oil_palm_a0_detect_url.clone();
             let openclaw_url = openclaw_url.clone();
             let sensor_schema_payload = sensor_schema_payload.clone();
             let registry_path = registry_path.clone();
@@ -439,6 +444,7 @@ pub fn start_http_server(
                         &image_index_path,
                         &image_db_error_store_path,
                         &ai_predict_url,
+                        ai_oil_palm_a0_detect_url.as_deref(),
                         &openclaw_url,
                         &sensor_schema_payload,
                         &registry_path,
@@ -506,6 +512,7 @@ fn handle_api(
     image_index_path: &str,
     image_db_error_store_path: &str,
     ai_predict_url: &str,
+    ai_oil_palm_a0_detect_url: Option<&str>,
     openclaw_url: &str,
     sensor_schema_payload: &str,
     registry_path: &str,
@@ -712,7 +719,15 @@ fn handle_api(
             } else if p.starts_with("/api/v1/sessions/") && p.ends_with("/images") {
                 let session_id = extract_path_segment(p, "/sessions/").unwrap_or_default();
                 if method == Method::Post {
-                    crate::session::handle_add_session_image(request, &session_id, query, image_store_path, db);
+                    crate::session::handle_add_session_image(
+                        request,
+                        &session_id,
+                        query,
+                        image_store_path,
+                        ai_oil_palm_a0_detect_url,
+                        ai_http_client,
+                        db,
+                    );
                 } else if method == Method::Get {
                     crate::session::handle_get_session_images(request, &session_id, db);
                 } else {

--- a/cloud/src/session.rs
+++ b/cloud/src/session.rs
@@ -2,8 +2,10 @@ use std::fs;
 use std::path::Path;
 use std::sync::{Arc, Mutex};
 
+use reqwest::blocking::Client;
 use tiny_http::{Request, Response};
 
+use crate::ai_client::detect_oil_palm_a0_from_bytes;
 use crate::db::DbManager;
 use crate::image_upload::{parse_boundary, parse_multipart_file, save_image_file, ImageUploadTag};
 use crate::time_util::now_rfc3339;
@@ -127,6 +129,8 @@ pub(crate) fn handle_add_session_image(
     session_id: &str,
     query: &str,
     image_store_path: &str,
+    ai_oil_palm_a0_detect_url: Option<&str>,
+    ai_http_client: &Client,
     db: Arc<Mutex<DbManager>>,
 ) {
     let sid = session_id.parse().unwrap_or(0);
@@ -238,18 +242,37 @@ pub(crate) fn handle_add_session_image(
         }
     };
 
-    let a0_review = a0_review_for_role(&image_role, tree_code, mock_detect_role.as_deref());
+    let a0_review = detect_a0_or_mock(
+        ai_http_client,
+        ai_oil_palm_a0_detect_url,
+        &file_part.body,
+        file_part.filename.as_deref(),
+        &persisted.image_type,
+        &image_role,
+        tree_code,
+        sid,
+        mock_detect_role.as_deref(),
+    );
     let a0_candidates = a0_review["metadata"]["a0_candidates"].clone();
-    let metadata = serde_json::json!({
-        "tree_code": tree_code,
-        "session_id": sid,
-        "session_code": session["session_code"],
-        "filename": file_part.filename,
-        "mock": true,
-        "a0_candidates": a0_candidates,
-        "route_status": a0_review["metadata"]["route_status"],
-        "downstream_status": "pending_user_confirmation"
-    });
+    let mut metadata = a0_review["metadata"].clone();
+    if !metadata.is_object() {
+        metadata = serde_json::json!({});
+    }
+    if let Some(obj) = metadata.as_object_mut() {
+        obj.insert("tree_code".to_string(), serde_json::json!(tree_code));
+        obj.insert("session_id".to_string(), serde_json::json!(sid));
+        obj.insert("session_code".to_string(), session["session_code"].clone());
+        obj.insert("filename".to_string(), serde_json::json!(file_part.filename));
+        obj.insert("a0_candidates".to_string(), a0_candidates);
+        obj.insert(
+            "route_status".to_string(),
+            a0_review["metadata"]["route_status"].clone(),
+        );
+        obj.insert(
+            "downstream_status".to_string(),
+            serde_json::json!("pending_user_confirmation"),
+        );
+    }
 
     let now = chrono::Utc::now();
     let db_record = crate::db::ImageUploadDbRecord {
@@ -292,7 +315,7 @@ pub(crate) fn handle_add_session_image(
             200,
             &serde_json::json!({
                 "status": "ok",
-                "requires_confirmation": true,
+                "requires_confirmation": a0_review["metadata"]["requires_user_confirmation"].as_bool().unwrap_or(false),
                 "image": image,
                 "analysis": a0_review
             })
@@ -624,6 +647,119 @@ fn mock_analysis_for_role(
             })),
             "model_version": "oil_palm_mock_session_v1"
         }),
+    }
+}
+
+fn detect_a0_or_mock(
+    client: &Client,
+    detect_url: Option<&str>,
+    image_bytes: &[u8],
+    filename: Option<&str>,
+    image_type: &str,
+    image_role: &str,
+    tree_code: &str,
+    session_id: i32,
+    mock_detect_role: Option<&str>,
+) -> serde_json::Value {
+    let Some(url) = detect_url else {
+        let mut review = a0_review_for_role(image_role, tree_code, mock_detect_role);
+        annotate_a0_metadata(
+            &mut review,
+            tree_code,
+            session_id,
+            "local_mock_no_ai_url",
+            None,
+            None,
+        );
+        return review;
+    };
+
+    match detect_oil_palm_a0_from_bytes(
+        client,
+        url,
+        image_bytes,
+        filename,
+        image_type,
+        image_role,
+        Some(tree_code),
+        Some(&session_id.to_string()),
+        mock_detect_role,
+    ) {
+        Ok(mut review) => {
+            annotate_a0_metadata(
+                &mut review,
+                tree_code,
+                session_id,
+                "ai_engine",
+                Some(url),
+                None,
+            );
+            review
+        }
+        Err(e) => {
+            eprintln!(
+                "[WARN] A0 AI Engine call failed for tree {} session {}: {}. Falling back to local mock A0.",
+                tree_code, session_id, e
+            );
+            let mut review = a0_review_for_role(image_role, tree_code, mock_detect_role);
+            annotate_a0_metadata(
+                &mut review,
+                tree_code,
+                session_id,
+                "local_mock_ai_error",
+                Some(url),
+                Some(&e),
+            );
+            review
+        }
+    }
+}
+
+fn annotate_a0_metadata(
+    review: &mut serde_json::Value,
+    tree_code: &str,
+    session_id: i32,
+    source: &str,
+    detect_url: Option<&str>,
+    error: Option<&str>,
+) {
+    if !review.is_object() {
+        *review = serde_json::json!({
+            "status": "success",
+            "results": [],
+            "geometry": [],
+            "metadata": {},
+            "model_version": "oil_palm_a0_detector_mock_v1"
+        });
+    }
+    if review.get("metadata").and_then(|v| v.as_object()).is_none() {
+        review["metadata"] = serde_json::json!({});
+    }
+    if let Some(obj) = review["metadata"].as_object_mut() {
+        obj.insert("crop".to_string(), serde_json::json!("oil_palm"));
+        obj.insert("tree_code".to_string(), serde_json::json!(tree_code));
+        obj.insert("session_id".to_string(), serde_json::json!(session_id));
+        obj.insert(
+            "downstream_status".to_string(),
+            serde_json::json!("pending_user_confirmation"),
+        );
+        obj.insert("a0_source".to_string(), serde_json::json!(source));
+        if let Some(url) = detect_url {
+            obj.insert("a0_detect_url".to_string(), serde_json::json!(url));
+        }
+        if let Some(message) = error {
+            obj.insert("a0_runtime_fallback".to_string(), serde_json::json!(true));
+            obj.insert("a0_runtime_error".to_string(), serde_json::json!(message));
+        }
+        let requires_confirmation = obj
+            .get("route_status")
+            .and_then(|v| v.as_str())
+            .map(|v| v == "needs_user_confirmation")
+            .unwrap_or(false);
+        obj.insert(
+            "requires_user_confirmation".to_string(),
+            serde_json::json!(requires_confirmation),
+        );
     }
 }
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -21,6 +21,11 @@ services:
       - MODEL_LABELS_FILE=/app/models/rice/rice_leaf_classifier/labels.json
       - MODEL_CONFIG_FILE=/app/models/rice/rice_leaf_classifier/config.yaml
       - MODEL_ADVICE_FILE=/app/models/rice/rice_leaf_classifier/advice_map.yaml
+      - OIL_PALM_MODEL_MODE=${OIL_PALM_MODEL_MODE:-mock}
+      - OIL_PALM_A0_MODEL_PATH=${OIL_PALM_A0_MODEL_PATH:-/app/models/oil_palm/a0_image_routing/runs/a0_yolo_structure_detector_v1/weights/best.pt}
+      - OIL_PALM_A0_LABELS_FILE=${OIL_PALM_A0_LABELS_FILE:-/app/models/oil_palm/a0_image_routing/labels.json}
+      - OIL_PALM_A0_CONFIG_FILE=${OIL_PALM_A0_CONFIG_FILE:-/app/models/oil_palm/a0_image_routing/inference_config.yaml}
+      - OIL_PALM_CONFIDENCE_THRESHOLD=${OIL_PALM_CONFIDENCE_THRESHOLD:-0.5}
     healthcheck:
       test: ["CMD", "python", "-c", "import urllib.request; urllib.request.urlopen('http://localhost:8000/api/v1/health')"]
       interval: 30s

--- a/models/oil_palm/README.md
+++ b/models/oil_palm/README.md
@@ -47,7 +47,7 @@ models/oil_palm/
 | `ffb_maturity` | object detection + maturity class | YOLO family | mock | 6 |
 | `uav_tree_crown` | object detection | YOLO family | mock | 1 |
 | `ganoderma_risk` | image classification | ResNet / EfficientNet | mock | 3 |
-| `a0_image_routing` | structure detection + routing | YOLOv8 | trained baseline artifact; runtime integration pending | 3 |
+| `a0_image_routing` | structure detection + routing | YOLOv8 | trained baseline artifact; AI Engine runtime supported | 3 |
 
 `growth_vigor` currently remains a mock pipeline task. The planned v1 is likely
 an aggregation score rather than a single-image trained model, so there is no
@@ -68,8 +68,8 @@ Future per-task branches will enable these path variables:
 - `OIL_PALM_A0_MODEL_PATH`
 
 The first trained A0 baseline records its local ignored artifact path in
-`models/oil_palm/a0_image_routing/inference_config.yaml`. Runtime code still
-uses the mock predictor until a real YOLO predictor is wired in.
+`models/oil_palm/a0_image_routing/inference_config.yaml`. Runtime code can load
+it through `OIL_PALM_A0_MODEL_PATH`; the weight file itself remains outside Git.
 
 Mode semantics in this foundation branch:
 

--- a/requirements/oil-palm-inference.txt
+++ b/requirements/oil-palm-inference.txt
@@ -1,9 +1,6 @@
 # Oil Palm inference dependencies
-# NOTE: ultralytics + torch will be added when the real YOLOv8 model is integrated.
-# For now, oil_palm endpoints are mock-only and don't need heavy ML deps.
 opencv-python-headless
-# --- Future (uncomment when real model is integrated) ---
-# ultralytics>=8.0
-# torch>=2.0
-# torchvision>=0.15
+ultralytics>=8.0
+torch>=2.0
+torchvision>=0.15
 # onnxruntime>=1.16

--- a/tests/README.md
+++ b/tests/README.md
@@ -27,4 +27,15 @@ python -m pytest -q
 
 # 跳过需要 PyTorch 的测试（CI 环境）
 python -m pytest -q -k "not torch"
+
+# 油棕 A0 路由与模型模式测试
+python -m pytest -q tests/test_oil_palm_routing.py tests/test_oil_palm_foundation.py
+
+# Rust cloud 单元与 smoke 测试
+cd cloud && cargo test
 ```
+
+注意：A0 real predictor 的单元测试使用 fake `ultralytics` 模块验证
+YOLO 输出到统一 envelope 的映射，不需要真实 `.pt` 权重。Cloud 的 session
+流程默认使用本地 mock A0；只有设置 `AI_OIL_PALM_A0_DETECT_URL` 时才会调用
+AI Engine 的 `/api/v1/oil-palm/a0/detect`。

--- a/tests/test_oil_palm_foundation.py
+++ b/tests/test_oil_palm_foundation.py
@@ -358,10 +358,14 @@ class TestPipelineMode:
     def test_pipeline_hybrid_mode_safely_uses_mock_predictors(
         self, monkeypatch: pytest.MonkeyPatch
     ) -> None:
-        """Foundation hybrid mode must not register unavailable real predictors."""
+        """Hybrid mode falls back safely when A0 real assets are unavailable."""
         monkeypatch.setenv(
             "OIL_PALM_FFB_MODEL_PATH",
             str(MODELS_OIL_PALM / "ffb_maturity" / "labels.json"),
+        )
+        monkeypatch.setenv(
+            "OIL_PALM_A0_MODEL_PATH",
+            str(MODELS_OIL_PALM / "a0_image_routing" / "missing_best.pt"),
         )
         pipeline_mod = self._reload_pipeline(monkeypatch, "hybrid")
 
@@ -386,10 +390,14 @@ class TestPipelineMode:
         assert result["model_version"].endswith("_mock_v1")
 
     def test_pipeline_real_mode_fails_fast(self, monkeypatch: pytest.MonkeyPatch) -> None:
-        """Real mode is intentionally unavailable until per-task model branches."""
+        """Real mode requires configured A0 runtime assets."""
+        monkeypatch.setenv(
+            "OIL_PALM_A0_MODEL_PATH",
+            str(MODELS_OIL_PALM / "a0_image_routing" / "missing_best.pt"),
+        )
         pipeline_mod = self._reload_pipeline(monkeypatch, "real")
 
-        with pytest.raises(RuntimeError, match="Real oil palm predictors"):
+        with pytest.raises(RuntimeError, match="A0 YOLO predictor"):
             pipeline_mod.build_default_oil_palm_pipeline()
 
     def test_a0_structure_detector_is_registered_as_mock(

--- a/tests/test_oil_palm_routing.py
+++ b/tests/test_oil_palm_routing.py
@@ -1,9 +1,16 @@
 from __future__ import annotations
 
+import io
+import sys
+import types
+
 from fastapi import FastAPI
 from fastapi.testclient import TestClient
+from PIL import Image
 
 from ai_engine.common.schemas.prediction import PredictionEnvelope
+from ai_engine.common.predictors.base import PredictorContext
+from ai_engine.crops.oil_palm.inference.a0_yolo_predictor import A0YoloPredictor
 from ai_engine.crops.oil_palm.inference.api import router
 
 
@@ -120,3 +127,130 @@ def test_oil_palm_a0_detect_reports_role_mismatch():
     payload = response.json()
     assert payload["metadata"]["route_status"] == "role_mismatch"
     assert payload["results"][0]["label"] == "trunk_base"
+
+
+def test_a0_yolo_predictor_maps_boxes_to_candidate_envelope(tmp_path, monkeypatch):
+    _install_fake_ultralytics(monkeypatch, cls_values=[0], conf_values=[0.92])
+    labels = tmp_path / "labels.json"
+    labels.write_text('["fruit_bunch", "trunk_base", "crown_region"]', encoding="utf-8")
+    config = tmp_path / "inference_config.yaml"
+    config.write_text(
+        "model_version: oil_palm_a0_test_v1\n"
+        "input_size: 128\n"
+        "confidence_threshold: 0.5\n"
+        "iou_threshold: 0.7\n"
+        "max_detections: 10\n",
+        encoding="utf-8",
+    )
+    weights = tmp_path / "best.pt"
+    weights.write_bytes(b"fake weights")
+
+    predictor = A0YoloPredictor(
+        weights_path=weights,
+        labels_path=labels,
+        config_path=config,
+    )
+    payload = predictor.predict(
+        _valid_png_bytes(),
+        PredictorContext(
+            crop="oil_palm",
+            task="a0_structure_detection",
+            image_role="fruit",
+            tree_code="OP-000001",
+        ),
+    )
+
+    envelope = PredictionEnvelope.model_validate(payload)
+    assert envelope.model_version == "oil_palm_a0_test_v1"
+    assert envelope.metadata["mock"] is False
+    assert envelope.metadata["route_status"] == "needs_user_confirmation"
+    assert envelope.metadata["requires_user_confirmation"] is True
+    assert envelope.metadata["detected_roles"] == ["fruit"]
+    assert envelope.results[0].label == "fruit_bunch"
+    assert envelope.results[0].geometry == {
+        "type": "bbox",
+        "x": 0.1,
+        "y": 0.2,
+        "w": 0.4,
+        "h": 0.6,
+    }
+
+
+def test_a0_yolo_predictor_reports_role_mismatch(tmp_path, monkeypatch):
+    _install_fake_ultralytics(monkeypatch, cls_values=[1], conf_values=[0.91])
+    labels = tmp_path / "labels.json"
+    labels.write_text('["fruit_bunch", "trunk_base", "crown_region"]', encoding="utf-8")
+    weights = tmp_path / "best.pt"
+    weights.write_bytes(b"fake weights")
+
+    predictor = A0YoloPredictor(weights_path=weights, labels_path=labels, config_path=None)
+    payload = predictor.predict(
+        _valid_png_bytes(),
+        PredictorContext(
+            crop="oil_palm",
+            task="a0_structure_detection",
+            image_role="fruit",
+        ),
+    )
+
+    assert payload["metadata"]["route_status"] == "role_mismatch"
+    assert payload["results"][0]["label"] == "trunk_base"
+    assert payload["metadata"]["detected_roles"] == ["trunk_base"]
+
+
+def test_oil_palm_hybrid_mode_registers_real_a0_when_available(
+    tmp_path,
+    monkeypatch,
+):
+    _install_fake_ultralytics(monkeypatch, cls_values=[0], conf_values=[0.9])
+    labels = tmp_path / "labels.json"
+    labels.write_text('["fruit_bunch", "trunk_base", "crown_region"]', encoding="utf-8")
+    weights = tmp_path / "best.pt"
+    weights.write_bytes(b"fake weights")
+
+    monkeypatch.setenv("OIL_PALM_MODEL_MODE", "hybrid")
+    monkeypatch.setenv("OIL_PALM_A0_MODEL_PATH", str(weights))
+    monkeypatch.setenv("OIL_PALM_A0_LABELS_FILE", str(labels))
+    monkeypatch.delenv("OIL_PALM_A0_CONFIG_FILE", raising=False)
+
+    import importlib
+    import ai_engine.crops.oil_palm.pipeline as pipeline_mod
+
+    pipeline_mod = importlib.reload(pipeline_mod)
+    pipeline = pipeline_mod.build_default_oil_palm_pipeline()
+
+    capabilities = pipeline.registry.capabilities("oil_palm")
+    a0 = [item for item in capabilities if item["task"] == "a0_structure_detection"]
+    assert a0[0]["mode"] == "real"
+    assert {item["mode"] for item in capabilities if item["task"] != "a0_structure_detection"} == {
+        "mock"
+    }
+
+
+def _valid_png_bytes() -> bytes:
+    image = Image.new("RGB", (100, 100), color=(120, 130, 140))
+    buffer = io.BytesIO()
+    image.save(buffer, format="PNG")
+    return buffer.getvalue()
+
+
+def _install_fake_ultralytics(monkeypatch, *, cls_values, conf_values):
+    fake_module = types.ModuleType("ultralytics")
+
+    class FakeBoxes:
+        xyxy = [[10.0, 20.0, 50.0, 80.0]]
+        cls = cls_values
+        conf = conf_values
+
+    class FakeResult:
+        boxes = FakeBoxes()
+
+    class FakeModel:
+        def __init__(self, weights_path):
+            self.weights_path = weights_path
+
+        def predict(self, **kwargs):
+            return [FakeResult()]
+
+    fake_module.YOLO = FakeModel
+    monkeypatch.setitem(sys.modules, "ultralytics", fake_module)


### PR DESCRIPTION
## Purpose

Connect the trained oil palm A0 structure-routing baseline to the runtime path without disturbing the tree-level asset workflow or the existing A0 data/training foundation already merged into `dev`.

A0 remains a gatekeeper: it detects `fruit_bunch`, `trunk_base`, and `crown_region` candidates for user confirmation. It does **not** diagnose disease, estimate maturity/yield, or replace structured tree/session storage.

## What Changed

- Added `A0YoloPredictor` in AI Engine for real YOLOv8 A0 inference.
- Updated oil palm pipeline modes:
  - `mock`: all oil palm predictors stay mock.
  - `hybrid`: load real A0 when weights/dependencies are available; keep downstream FFB/Ganoderma/Growth/UAV predictors as mock fallback.
  - `real`: fail fast if A0 real runtime assets are missing or unusable.
- Added Cloud-side A0 detect client wiring for observation session uploads.
- Added optional `AI_OIL_PALM_A0_DETECT_URL` for Cloud.
- Preserved local mock A0 fallback when Cloud has no A0 URL configured or the AI Engine call fails.
- Documented A0 runtime env vars in README, AI Engine docs, Cloud docs, compose config, and tests README.
- Added unit coverage for real A0 output mapping, role mismatch behavior, and hybrid-mode registration.

## Runtime Configuration

AI Engine real/hybrid A0 runtime expects:

```bash
CROP_PROFILE=oil_palm
OIL_PALM_MODEL_MODE=hybrid   # or real
OIL_PALM_A0_MODEL_PATH=models/oil_palm/a0_image_routing/runs/a0_yolo_structure_detector_v1/weights/best.pt
OIL_PALM_A0_LABELS_FILE=models/oil_palm/a0_image_routing/labels.json
OIL_PALM_A0_CONFIG_FILE=models/oil_palm/a0_image_routing/inference_config.yaml
OIL_PALM_CONFIDENCE_THRESHOLD=0.5
```

Cloud calls A0 only when this is configured:

```bash
AI_OIL_PALM_A0_DETECT_URL=http://ai-engine:8000/api/v1/oil-palm/a0/detect
```

If unset, Cloud keeps using the local mock A0 contract so Tree Profile session collection remains available.

## Behavior Notes

- `needs_user_confirmation` returns bbox candidates and allows the existing frontend confirmation flow.
- `role_mismatch` and `no_supported_structure_detected` fail safely by not pretending the image is valid downstream evidence.
- A0 weights remain outside Git and must be mounted or supplied by deployment artifacts.
- Downstream FFB/Ganoderma/Growth/UAV predictors are still mock in this PR.

## Impact

- Does not modify rice endpoints or rice model loading.
- Does not remove legacy `/api/v1/predict`.
- Does not change schema envelope fields: `status`, `results`, `geometry`, `metadata`, `model_version` are preserved.
- Does not add model weights to Git.
- No database migration required.

## Validation

```bash
python -m pytest -q tests\test_oil_palm_routing.py tests\test_oil_palm_foundation.py --basetemp target\pytest-tmp -p no:cacheprovider
# 61 passed

python -m pytest -q tests\test_adapter.py tests\test_api.py tests\test_infer_smoke.py tests\test_oil_palm_foundation.py tests\test_oil_palm_routing.py tests\test_openclaw_chat_adapter.py tests\test_prepare_dataset.py tests\test_schemas.py --basetemp target\pytest-local-tmp -p no:cacheprovider
# 78 passed, 11 skipped

cd cloud && cargo test
# 28 unit tests + 2 smoke tests passed

python -m ai_engine.infer --help
# OK
```

Full `python -m pytest -q` was not used as the final gate because the repository includes live-server E2E tests that expect services such as Cloud at `127.0.0.1:8088` to already be running.

## Follow-up Before Production Enablement

- Run AI Engine with the real `best.pt` mounted and manually test representative fruit/trunk/crown images.
- Configure Cloud with `AI_OIL_PALM_A0_DETECT_URL` in the target deployment environment.
- Add negative/unsupported-image A0 evaluation before enabling any future auto-routing mode.