### PR TITLE
fix(frontend): exclude category metric from trend charts

### DIFF
--- a/frontend/rice/ui.js
+++ b/frontend/rice/ui.js
@@ -830,6 +830,12 @@ window.UI = (() => {
                 }
 
                 fieldSpecs.forEach(({ fieldName, fieldSpec }) => {
+                    const normalizedField = `${fieldName || ''}`.trim().toLowerCase();
+                    if (!normalizedField) return;
+                    const categoryMetric = `${schema?.categoryMetric || ''}`.trim().toLowerCase();
+                    // Category metric is for classification/grouping, not time-series trend lines.
+                    if (categoryMetric && normalizedField === categoryMetric) return;
+
                     const numericTypes = ['number', 'float', 'f32', 'f64', 'u8', 'u16', 'u32', 'u64', 'i32', 'i64'];
                     if (!numericTypes.includes(`${fieldSpec.data_type || ''}`.toLowerCase())) return;
 


### PR DESCRIPTION
This pull request improves the robustness of the field selection logic in the `frontend/rice/ui.js` file. The main change ensures that fields used as category metrics are excluded from being treated as numeric fields for time-series trend lines, which helps prevent incorrect data visualizations.

**Field selection and validation improvements:**

* Added logic to normalize and validate field names before processing, ensuring empty or invalid field names are skipped.
* Excluded fields matching the `categoryMetric` from being considered for numeric trend lines, as category metrics are intended for classification or grouping, not for time-series analysis.